### PR TITLE
Add GitHub Actions workflows for building and releasing APK

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,6 +18,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platforms;android-34
+            build-tools;34.0.0
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -26,7 +26,7 @@ jobs:
             platforms;android-34
             build-tools;34.0.0
             cmake;3.22.1
-            ndk-bundle
+            ndk;25.2.9519653
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,11 +22,17 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           packages: |
+            platform-tools
             platforms;android-34
             build-tools;34.0.0
+            cmake;3.22.1
+            ndk-bundle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Configure SDK path
+        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,12 +23,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          packages: |
-            platform-tools
-            platforms;android-34
-            build-tools;34.0.0
-            cmake;3.22.1
-            ndk;25.2.9519653
+          packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,31 @@
+name: Build Dev APK
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apk
+          path: ImguiDemoSdl/build/outputs/apk/debug/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          packages: |
-            platform-tools
-            platforms;android-34
-            build-tools;34.0.0
-            cmake;3.22.1
-            ndk;25.2.9519653
+          packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             platforms;android-34
             build-tools;34.0.0
             cmake;3.22.1
-            ndk-bundle
+            ndk;25.2.9519653
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Build and Release APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: ImguiDemoSdl/build/outputs/apk/release/*.apk
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ImguiDemoSdl/build/outputs/apk/release/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platforms;android-34
+            build-tools;34.0.0
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,17 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           packages: |
+            platform-tools
             platforms;android-34
             build-tools;34.0.0
+            cmake;3.22.1
+            ndk-bundle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Configure SDK path
+        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -6,6 +6,7 @@ plugins {
 android {
     namespace = "me.sfalexrog.imguidemo"
     compileSdkVersion 34
+    ndkVersion "25.2.9519653"
 //    buildToolsVersion "30.0.2"
     defaultConfig {
         applicationId "me.sfalexrog.imguidemo"


### PR DESCRIPTION
## Summary
- build Android release APK with Gradle on tag pushes or manual dispatch
- build debug APK on every commit and upload artifact
- upload generated APK artifact and attach it to a GitHub release

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee0162db88320b5959537eb5e758d