### PR TITLE
Upload APK directly

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,8 +34,12 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+      - name: Publish debug APK
+        uses: softprops/action-gh-release@v1
         with:
-          name: debug-apk
-          path: ImguiDemoSdl/build/outputs/apk/debug/*.apk
+          tag_name: debug-${{ github.sha }}
+          name: "Debug build ${{ github.sha }}"
+          prerelease: true
+          files: ImguiDemoSdl/build/outputs/apk/debug/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,6 @@ jobs:
       - name: Build release APK
         run: ./gradlew assembleRelease
 
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-apk
-          path: ImguiDemoSdl/build/outputs/apk/release/*.apk
-
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
- Publish debug build to a GitHub prerelease instead of zipped artifact
- Remove redundant artifact upload from release workflow

## Testing
- `./gradlew tasks` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fff26dd808320bb8c6cbd0e4d382a