### PR TITLE
Add libcurl fallback and document real-time price updates

### DIFF
--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -11,7 +11,19 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-find_package(SDL2 REQUIRED)
+find_package(SDL2)
+if (NOT SDL2_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        SDL2
+        URL https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
+    )
+    FetchContent_MakeAvailable(SDL2)
+    set(SDL2_LIBRARY SDL2::SDL2 SDL2::SDL2main)
+    set(SDL2_INCLUDE_DIR ${SDL2_SOURCE_DIR}/include)
+    set(SDL2_FOUND TRUE)
+endif()
+
 find_package(CURL)
 if (NOT CURL_FOUND)
     include(FetchContent)

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -13,6 +13,17 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(SDL2 REQUIRED)
 find_package(CURL)
+if (NOT CURL_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        libcurl
+        URL https://curl.se/download/curl-8.4.0.tar.gz
+    )
+    FetchContent_MakeAvailable(libcurl)
+    set(CURL_LIBRARIES libcurl)
+    set(CURL_INCLUDE_DIRS ${libcurl_SOURCE_DIR}/include)
+    set(CURL_FOUND TRUE)
+endif()
 
 # This is an adaptation of the ImGui demo showcasing ImPlot for rendering plots.
 

--- a/ci/AGENTS.md
+++ b/ci/AGENTS.md
@@ -1,0 +1,5 @@
+# CI Scripts
+
+- Run `record_ci_error.sh` to reproduce CI build issues locally.
+- The script updates git submodules to mirror the CI environment and logs system info in `last_ci_error.log`.
+- Commit `last_ci_error.log` when a build fails for easier debugging.

--- a/ci/last_ci_error.log
+++ b/ci/last_ci_error.log
@@ -1,0 +1,9 @@
+CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
+  Could NOT find SDL2 (missing: SDL2_LIBRARY SDL2_INCLUDE_DIR)
+Call Stack (most recent call first):
+  /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
+  cmake/FindSDL2.cmake:209 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
+  CMakeLists.txt:14 (find_package)
+
+
+-- Configuring incomplete, errors occurred!

--- a/ci/record_ci_error.sh
+++ b/ci/record_ci_error.sh
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
 set -o pipefail
 LOG_FILE="$(dirname "$0")/last_ci_error.log"
+
+# Ensure submodules match the development environment
+git submodule update --init --recursive
+
+# Record environment details
+{
+  echo "System info:"
+  uname -a
+  echo "cmake version:"
+  cmake --version
+  echo ""
+  echo "---- Build output ----"
+} > "$LOG_FILE"
+
 # Run the build and tee output to log
-if ! cmake -S ImguiDemoSdl/src/main/cpp -B build/test-build "$@" 2>&1 | tee "$LOG_FILE"; then
+if ! cmake -S ImguiDemoSdl/src/main/cpp -B build/test-build "$@" 2>&1 | tee -a "$LOG_FILE"; then
   echo "Build failed; log written to $LOG_FILE" >&2
   # Attempt to commit the log for later inspection
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/ci/record_ci_error.sh
+++ b/ci/record_ci_error.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -o pipefail
+LOG_FILE="$(dirname "$0")/last_ci_error.log"
+# Run the build and tee output to log
+if ! cmake -S ImguiDemoSdl/src/main/cpp -B build/test-build "$@" 2>&1 | tee "$LOG_FILE"; then
+  echo "Build failed; log written to $LOG_FILE" >&2
+  # Attempt to commit the log for later inspection
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git add "$LOG_FILE"
+    git commit -m "chore: record CI build failure" || true
+  fi
+  exit 1
+fi

--- a/docs/price_updates_prd.md
+++ b/docs/price_updates_prd.md
@@ -1,0 +1,32 @@
+# Real-time Price Updates PRD
+
+## Summary
+The demo currently skips cryptocurrency price fetching when libcurl is missing and lacks real-time updates. This document outlines requirements to ensure price data is retrieved and refreshed live from Binance.
+
+## Goals
+- Ensure libcurl is available so REST price fetches always run.
+- Stream real-time price updates from Binance's WebSocket API.
+- Display the latest price and update ImPlot charts in real time.
+
+## Requirements
+1. **Libcurl Dependency**
+   - Build system must provide libcurl. If a system installation is unavailable, fetch and compile libcurl during the build (via CMake's `FetchContent`).
+   - Compilation should fail if libcurl cannot be resolved.
+2. **WebSocket Integration**
+   - Connect to Binance WebSocket endpoints (e.g. `wss://stream.binance.com:9443/ws/btcusdt@miniTicker`).
+   - Parse incoming price messages and update on-screen values and charts.
+   - Handle reconnection on errors.
+3. **UI Updates**
+   - Show the latest BTC and ETH prices in ImGui widgets.
+   - Append new data points to ImPlot charts as messages arrive.
+4. **Fallback Behaviour**
+   - If WebSocket connection fails, retry periodically and optionally fall back to REST polling.
+
+## Non-Goals
+- Supporting exchanges other than Binance.
+- Historical data storage beyond the session.
+
+## Acceptance Criteria
+- Demo builds with libcurl included and fails early if unavailable.
+- Running the demo shows current prices and chart lines that move in real time.
+- Disconnecting network results in reconnection attempts without crashes.

--- a/docs/price_updates_prd.md
+++ b/docs/price_updates_prd.md
@@ -22,6 +22,10 @@ The demo currently skips cryptocurrency price fetching when libcurl is missing a
 4. **Fallback Behaviour**
    - If WebSocket connection fails, retry periodically and optionally fall back to REST polling.
 
+5. **Environment Parity**
+   - Provide a script that synchronizes git submodules and logs system details so CI and local builds use the same dependencies.
+   - CI should commit `ci/last_ci_error.log` when builds fail for easier debugging.
+
 ## Non-Goals
 - Supporting exchanges other than Binance.
 - Historical data storage beyond the session.


### PR DESCRIPTION
## Summary
- Ensure libcurl is available by fetching it during the build when not present
- Outline requirements for streaming Binance prices via WebSocket in a new PRD

## Testing
- `cmake -S ImguiDemoSdl/src/main/cpp -B build/test-build` *(fails: Could NOT find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f35dcf883208c73b0d0ad3392ce