### PR TITLE
Display build number overlay

### DIFF
--- a/ImguiDemoSdl/src/main/java/me/sfalexrog/imguidemo/DemoActivity.java
+++ b/ImguiDemoSdl/src/main/java/me/sfalexrog/imguidemo/DemoActivity.java
@@ -1,5 +1,7 @@
 package me.sfalexrog.imguidemo;
 
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -76,7 +78,13 @@ public class DemoActivity extends SDLActivity {
             }
         }
         TextView buildView = new TextView(this);
-        String buildText = BuildConfig.VERSION_NAME + " (" + BuildConfig.VERSION_CODE + ")";
+        String buildText;
+        try {
+            PackageInfo pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
+            buildText = pInfo.versionName + " (" + pInfo.versionCode + ")";
+        } catch (PackageManager.NameNotFoundException e) {
+            buildText = "Unknown";
+        }
         buildView.setText(buildText);
         buildView.setTextColor(Color.WHITE);
         buildView.setBackgroundColor(0x66000000);

--- a/ImguiDemoSdl/src/main/java/me/sfalexrog/imguidemo/DemoActivity.java
+++ b/ImguiDemoSdl/src/main/java/me/sfalexrog/imguidemo/DemoActivity.java
@@ -1,8 +1,12 @@
 package me.sfalexrog.imguidemo;
 
 import android.content.res.AssetManager;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.Gravity;
+import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import org.libsdl.app.SDLActivity;
 
@@ -71,6 +75,15 @@ public class DemoActivity extends SDLActivity {
                 Log.e(TAG, "Could not open " + assetName + " from assets, that should not happen", e);
             }
         }
-
+        TextView buildView = new TextView(this);
+        String buildText = BuildConfig.VERSION_NAME + " (" + BuildConfig.VERSION_CODE + ")";
+        buildView.setText(buildText);
+        buildView.setTextColor(Color.WHITE);
+        buildView.setBackgroundColor(0x66000000);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.BOTTOM | Gravity.END);
+        addContentView(buildView, params);
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 A demo of dear imgui running on Android
 ![screenshot](https://raw.githubusercontent.com/sfalexrog/Imgui_Android/master/screenshot/screenshot.png)
 
+The running build number is displayed in the corner for quick version identification.
+
 ## What?
 
 This is a port of [dear imgui](https://github.com/ocornut/imgui) SDL2 example to Android. It now showcases [ImPlot](https://github.com/epezent/implot) by streaming Bitcoin and Ethereum prices from the [Binance WebSocket API](https://binance.com/en/binance-api) and plotting them in real time.


### PR DESCRIPTION
## Summary
- show build number overlay in DemoActivity for quick version identification
- document build number overlay in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0400258608320a50e95f1b981fc10