### PR TITLE
Add Material-inspired ImGui theme

### DIFF
--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -106,51 +106,55 @@ static SDL_GLContext createCtx(SDL_Window *w)
     return ctx;
 }
 
-static void ApplyMaterialStyle() {
+static void ApplyIOSStyle() {
     ImGuiStyle& style = ImGui::GetStyle();
     ImVec4* colors = style.Colors;
-    const ImVec4 accent(0.0f, 0.78f, 0.55f, 1.0f);
-    const ImVec4 bg(0.07f, 0.07f, 0.07f, 1.0f);
-    const ImVec4 surface(0.16f, 0.16f, 0.16f, 1.0f);
+    const ImVec4 accent(0.0f, 0.48f, 1.0f, 1.0f); // iOS blue
+    const ImVec4 bg(0.97f, 0.97f, 0.97f, 1.0f);
+    const ImVec4 surface(1.0f, 1.0f, 1.0f, 1.0f);
 
-    colors[ImGuiCol_Text]               = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    colors[ImGuiCol_Text]               = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
     colors[ImGuiCol_WindowBg]           = bg;
     colors[ImGuiCol_ChildBg]            = bg;
     colors[ImGuiCol_PopupBg]            = surface;
-    colors[ImGuiCol_Border]             = ImVec4(0.2f, 0.2f, 0.2f, 1.0f);
+    colors[ImGuiCol_Border]             = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     colors[ImGuiCol_FrameBg]            = surface;
-    colors[ImGuiCol_FrameBgHovered]     = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
-    colors[ImGuiCol_FrameBgActive]      = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_FrameBgHovered]     = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
+    colors[ImGuiCol_FrameBgActive]      = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     colors[ImGuiCol_TitleBg]            = bg;
     colors[ImGuiCol_TitleBgActive]      = surface;
     colors[ImGuiCol_TitleBgCollapsed]   = bg;
     colors[ImGuiCol_CheckMark]          = accent;
     colors[ImGuiCol_SliderGrab]         = accent;
-    colors[ImGuiCol_SliderGrabActive]   = ImVec4(0.0f, 0.85f, 0.60f, 1.0f);
+    colors[ImGuiCol_SliderGrabActive]   = ImVec4(0.0f, 0.6f, 1.0f, 1.0f);
     colors[ImGuiCol_Button]             = surface;
-    colors[ImGuiCol_ButtonHovered]      = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
-    colors[ImGuiCol_ButtonActive]       = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_ButtonHovered]      = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
+    colors[ImGuiCol_ButtonActive]       = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     colors[ImGuiCol_Header]             = surface;
-    colors[ImGuiCol_HeaderHovered]      = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
-    colors[ImGuiCol_HeaderActive]       = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_HeaderHovered]      = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
+    colors[ImGuiCol_HeaderActive]       = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     colors[ImGuiCol_Tab]                = surface;
-    colors[ImGuiCol_TabHovered]         = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
-    colors[ImGuiCol_TabActive]          = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_TabHovered]         = colors[ImGuiCol_ButtonHovered];
+    colors[ImGuiCol_TabActive]          = colors[ImGuiCol_ButtonActive];
     colors[ImGuiCol_TabUnfocused]       = surface;
-    colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
-    colors[ImGuiCol_Separator]          = ImVec4(0.28f, 0.28f, 0.28f, 1.0f);
+    colors[ImGuiCol_TabUnfocusedActive] = colors[ImGuiCol_TabActive];
+    colors[ImGuiCol_Separator]          = ImVec4(0.86f, 0.86f, 0.86f, 1.0f);
     colors[ImGuiCol_ResizeGrip]         = surface;
-    colors[ImGuiCol_ResizeGripHovered]  = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
-    colors[ImGuiCol_ResizeGripActive]   = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_ResizeGripHovered]  = colors[ImGuiCol_ButtonHovered];
+    colors[ImGuiCol_ResizeGripActive]   = colors[ImGuiCol_ButtonActive];
     colors[ImGuiCol_ScrollbarBg]        = surface;
-    colors[ImGuiCol_ScrollbarGrab]      = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
-    colors[ImGuiCol_ScrollbarGrabHovered]= ImVec4(0.37f, 0.37f, 0.37f, 1.0f);
-    colors[ImGuiCol_ScrollbarGrabActive]= ImVec4(0.41f, 0.41f, 0.41f, 1.0f);
+    colors[ImGuiCol_ScrollbarGrab]      = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
+    colors[ImGuiCol_ScrollbarGrabHovered]= ImVec4(0.7f, 0.7f, 0.7f, 1.0f);
+    colors[ImGuiCol_ScrollbarGrabActive]= ImVec4(0.6f, 0.6f, 0.6f, 1.0f);
 
-    style.WindowRounding = 6.0f;
-    style.FrameRounding = 6.0f;
-    style.GrabRounding = 6.0f;
-    style.ScrollbarRounding = 6.0f;
+    style.WindowRounding = 8.0f;
+    style.FrameRounding = 8.0f;
+    style.GrabRounding = 8.0f;
+    style.ScrollbarRounding = 8.0f;
+    style.FramePadding = ImVec2(12.0f, 8.0f);
+    style.ItemSpacing = ImVec2(10.0f, 10.0f);
+    style.TouchExtraPadding = ImVec2(4.0f, 4.0f);
+    style.ScrollbarSize = 20.0f;
 
     ImPlotStyle& plotStyle = ImPlot::GetStyle();
     plotStyle.Colors[ImPlotCol_Line]          = accent;
@@ -159,18 +163,18 @@ static void ApplyMaterialStyle() {
     plotStyle.Colors[ImPlotCol_MarkerFill]    = accent;
     plotStyle.Colors[ImPlotCol_FrameBg]       = surface;
     plotStyle.Colors[ImPlotCol_PlotBg]        = bg;
-    plotStyle.Colors[ImPlotCol_PlotBorder]    = ImVec4(0.2f, 0.2f, 0.2f, 1.0f);
+    plotStyle.Colors[ImPlotCol_PlotBorder]    = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     plotStyle.Colors[ImPlotCol_LegendBg]      = surface;
     plotStyle.Colors[ImPlotCol_LegendBorder]  = plotStyle.Colors[ImPlotCol_PlotBorder];
-    plotStyle.Colors[ImPlotCol_LegendText]    = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
-    plotStyle.Colors[ImPlotCol_TitleText]     = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisText]      = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisGrid]      = ImVec4(0.28f, 0.28f, 0.28f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisTick]      = ImVec4(0.28f, 0.28f, 0.28f, 1.0f);
+    plotStyle.Colors[ImPlotCol_LegendText]    = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+    plotStyle.Colors[ImPlotCol_TitleText]     = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisText]      = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisGrid]      = ImVec4(0.86f, 0.86f, 0.86f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisTick]      = ImVec4(0.86f, 0.86f, 0.86f, 1.0f);
     plotStyle.Colors[ImPlotCol_AxisBgHovered] = colors[ImGuiCol_ButtonHovered];
     plotStyle.Colors[ImPlotCol_AxisBgActive]  = colors[ImGuiCol_ButtonActive];
     plotStyle.Colors[ImPlotCol_Selection]     = ImVec4(accent.x, accent.y, accent.z, 0.25f);
-    plotStyle.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.0f, 1.0f, 1.0f, 0.5f);
+    plotStyle.Colors[ImPlotCol_Crosshairs]    = ImVec4(0.0f, 0.0f, 0.0f, 0.5f);
 }
 
 int main(int argc, char** argv)
@@ -208,8 +212,8 @@ int main(int argc, char** argv)
     ImGui_ImplSDL2_InitForOpenGL(window, ctx);
     ImGui_ImplOpenGL3_Init(imguiShaderVersions); // Select proper OpenGL version automagically
 
-    ImGui::StyleColorsDark();
-    ApplyMaterialStyle();
+    ImGui::StyleColorsLight();
+    ApplyIOSStyle();
 
     // Load Fonts
     // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
@@ -221,7 +225,7 @@ int main(int argc, char** argv)
 
     bool show_test_window = true;
     bool show_another_window = false;
-    ImVec4 clear_color = ImVec4(0.07f, 0.07f, 0.07f, 1.0f);
+    ImVec4 clear_color = ImVec4(0.97f, 0.97f, 0.97f, 1.0f);
 
     std::vector<double> btc_x, btc_prices;
     std::vector<double> eth_x, eth_prices;

--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -106,7 +106,72 @@ static SDL_GLContext createCtx(SDL_Window *w)
     return ctx;
 }
 
+static void ApplyMaterialStyle() {
+    ImGuiStyle& style = ImGui::GetStyle();
+    ImVec4* colors = style.Colors;
+    const ImVec4 accent(0.0f, 0.78f, 0.55f, 1.0f);
+    const ImVec4 bg(0.07f, 0.07f, 0.07f, 1.0f);
+    const ImVec4 surface(0.16f, 0.16f, 0.16f, 1.0f);
 
+    colors[ImGuiCol_Text]               = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    colors[ImGuiCol_WindowBg]           = bg;
+    colors[ImGuiCol_ChildBg]            = bg;
+    colors[ImGuiCol_PopupBg]            = surface;
+    colors[ImGuiCol_Border]             = ImVec4(0.2f, 0.2f, 0.2f, 1.0f);
+    colors[ImGuiCol_FrameBg]            = surface;
+    colors[ImGuiCol_FrameBgHovered]     = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
+    colors[ImGuiCol_FrameBgActive]      = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_TitleBg]            = bg;
+    colors[ImGuiCol_TitleBgActive]      = surface;
+    colors[ImGuiCol_TitleBgCollapsed]   = bg;
+    colors[ImGuiCol_CheckMark]          = accent;
+    colors[ImGuiCol_SliderGrab]         = accent;
+    colors[ImGuiCol_SliderGrabActive]   = ImVec4(0.0f, 0.85f, 0.60f, 1.0f);
+    colors[ImGuiCol_Button]             = surface;
+    colors[ImGuiCol_ButtonHovered]      = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
+    colors[ImGuiCol_ButtonActive]       = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_Header]             = surface;
+    colors[ImGuiCol_HeaderHovered]      = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
+    colors[ImGuiCol_HeaderActive]       = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_Tab]                = surface;
+    colors[ImGuiCol_TabHovered]         = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
+    colors[ImGuiCol_TabActive]          = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_TabUnfocused]       = surface;
+    colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_Separator]          = ImVec4(0.28f, 0.28f, 0.28f, 1.0f);
+    colors[ImGuiCol_ResizeGrip]         = surface;
+    colors[ImGuiCol_ResizeGripHovered]  = ImVec4(0.26f, 0.26f, 0.26f, 1.0f);
+    colors[ImGuiCol_ResizeGripActive]   = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_ScrollbarBg]        = surface;
+    colors[ImGuiCol_ScrollbarGrab]      = ImVec4(0.33f, 0.33f, 0.33f, 1.0f);
+    colors[ImGuiCol_ScrollbarGrabHovered]= ImVec4(0.37f, 0.37f, 0.37f, 1.0f);
+    colors[ImGuiCol_ScrollbarGrabActive]= ImVec4(0.41f, 0.41f, 0.41f, 1.0f);
+
+    style.WindowRounding = 6.0f;
+    style.FrameRounding = 6.0f;
+    style.GrabRounding = 6.0f;
+    style.ScrollbarRounding = 6.0f;
+
+    ImPlotStyle& plotStyle = ImPlot::GetStyle();
+    plotStyle.Colors[ImPlotCol_Line]          = accent;
+    plotStyle.Colors[ImPlotCol_Fill]          = ImVec4(accent.x, accent.y, accent.z, 0.25f);
+    plotStyle.Colors[ImPlotCol_MarkerOutline] = accent;
+    plotStyle.Colors[ImPlotCol_MarkerFill]    = accent;
+    plotStyle.Colors[ImPlotCol_FrameBg]       = surface;
+    plotStyle.Colors[ImPlotCol_PlotBg]        = bg;
+    plotStyle.Colors[ImPlotCol_PlotBorder]    = ImVec4(0.2f, 0.2f, 0.2f, 1.0f);
+    plotStyle.Colors[ImPlotCol_LegendBg]      = surface;
+    plotStyle.Colors[ImPlotCol_LegendBorder]  = plotStyle.Colors[ImPlotCol_PlotBorder];
+    plotStyle.Colors[ImPlotCol_LegendText]    = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    plotStyle.Colors[ImPlotCol_TitleText]     = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisText]      = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisGrid]      = ImVec4(0.28f, 0.28f, 0.28f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisTick]      = ImVec4(0.28f, 0.28f, 0.28f, 1.0f);
+    plotStyle.Colors[ImPlotCol_AxisBgHovered] = colors[ImGuiCol_ButtonHovered];
+    plotStyle.Colors[ImPlotCol_AxisBgActive]  = colors[ImGuiCol_ButtonActive];
+    plotStyle.Colors[ImPlotCol_Selection]     = ImVec4(accent.x, accent.y, accent.z, 0.25f);
+    plotStyle.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.0f, 1.0f, 1.0f, 0.5f);
+}
 
 int main(int argc, char** argv)
 {
@@ -144,6 +209,7 @@ int main(int argc, char** argv)
     ImGui_ImplOpenGL3_Init(imguiShaderVersions); // Select proper OpenGL version automagically
 
     ImGui::StyleColorsDark();
+    ApplyMaterialStyle();
 
     // Load Fonts
     // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
@@ -155,7 +221,7 @@ int main(int argc, char** argv)
 
     bool show_test_window = true;
     bool show_another_window = false;
-    ImVec4 clear_color = ImColor(114, 144, 154);
+    ImVec4 clear_color = ImVec4(0.07f, 0.07f, 0.07f, 1.0f);
 
     std::vector<double> btc_x, btc_prices;
     std::vector<double> eth_x, eth_prices;

--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -106,55 +106,44 @@ static SDL_GLContext createCtx(SDL_Window *w)
     return ctx;
 }
 
-static void ApplyIOSStyle() {
+static void ApplyMaterialTheme(bool dark, ImVec4& clear_color) {
     ImGuiStyle& style = ImGui::GetStyle();
     ImVec4* colors = style.Colors;
-    const ImVec4 accent(0.0f, 0.48f, 1.0f, 1.0f); // iOS blue
-    const ImVec4 bg(0.97f, 0.97f, 0.97f, 1.0f);
-    const ImVec4 surface(1.0f, 1.0f, 1.0f, 1.0f);
+    ImVec4 accent(0.38f, 0.0f, 0.92f, 1.0f); // bright Material purple
+    ImVec4 bg = dark ? ImVec4(0.12f, 0.12f, 0.12f, 1.0f) : ImVec4(0.95f, 0.95f, 0.95f, 1.0f);
+    ImVec4 surface = dark ? ImVec4(0.18f, 0.18f, 0.18f, 1.0f) : ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    ImVec4 text = dark ? ImVec4(1.0f, 1.0f, 1.0f, 1.0f) : ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
 
-    colors[ImGuiCol_Text]               = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+    if (dark)
+        ImGui::StyleColorsDark();
+    else
+        ImGui::StyleColorsLight();
+
+    colors[ImGuiCol_Text]               = text;
     colors[ImGuiCol_WindowBg]           = bg;
     colors[ImGuiCol_ChildBg]            = bg;
     colors[ImGuiCol_PopupBg]            = surface;
-    colors[ImGuiCol_Border]             = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     colors[ImGuiCol_FrameBg]            = surface;
-    colors[ImGuiCol_FrameBgHovered]     = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
-    colors[ImGuiCol_FrameBgActive]      = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
-    colors[ImGuiCol_TitleBg]            = bg;
-    colors[ImGuiCol_TitleBgActive]      = surface;
-    colors[ImGuiCol_TitleBgCollapsed]   = bg;
-    colors[ImGuiCol_CheckMark]          = accent;
-    colors[ImGuiCol_SliderGrab]         = accent;
-    colors[ImGuiCol_SliderGrabActive]   = ImVec4(0.0f, 0.6f, 1.0f, 1.0f);
-    colors[ImGuiCol_Button]             = surface;
-    colors[ImGuiCol_ButtonHovered]      = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
-    colors[ImGuiCol_ButtonActive]       = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
-    colors[ImGuiCol_Header]             = surface;
-    colors[ImGuiCol_HeaderHovered]      = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
-    colors[ImGuiCol_HeaderActive]       = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
+    colors[ImGuiCol_FrameBgHovered]     = ImVec4(accent.x, accent.y, accent.z, 0.4f);
+    colors[ImGuiCol_FrameBgActive]      = ImVec4(accent.x, accent.y, accent.z, 0.6f);
+    colors[ImGuiCol_Button]             = ImVec4(accent.x, accent.y, accent.z, 0.8f);
+    colors[ImGuiCol_ButtonHovered]      = ImVec4(accent.x, accent.y, accent.z, 1.0f);
+    colors[ImGuiCol_ButtonActive]       = ImVec4(accent.x, accent.y, accent.z, 0.6f);
+    colors[ImGuiCol_Header]             = ImVec4(accent.x, accent.y, accent.z, 0.8f);
+    colors[ImGuiCol_HeaderHovered]      = ImVec4(accent.x, accent.y, accent.z, 1.0f);
+    colors[ImGuiCol_HeaderActive]       = ImVec4(accent.x, accent.y, accent.z, 0.6f);
     colors[ImGuiCol_Tab]                = surface;
     colors[ImGuiCol_TabHovered]         = colors[ImGuiCol_ButtonHovered];
     colors[ImGuiCol_TabActive]          = colors[ImGuiCol_ButtonActive];
     colors[ImGuiCol_TabUnfocused]       = surface;
     colors[ImGuiCol_TabUnfocusedActive] = colors[ImGuiCol_TabActive];
-    colors[ImGuiCol_Separator]          = ImVec4(0.86f, 0.86f, 0.86f, 1.0f);
-    colors[ImGuiCol_ResizeGrip]         = surface;
-    colors[ImGuiCol_ResizeGripHovered]  = colors[ImGuiCol_ButtonHovered];
-    colors[ImGuiCol_ResizeGripActive]   = colors[ImGuiCol_ButtonActive];
-    colors[ImGuiCol_ScrollbarBg]        = surface;
-    colors[ImGuiCol_ScrollbarGrab]      = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
-    colors[ImGuiCol_ScrollbarGrabHovered]= ImVec4(0.7f, 0.7f, 0.7f, 1.0f);
-    colors[ImGuiCol_ScrollbarGrabActive]= ImVec4(0.6f, 0.6f, 0.6f, 1.0f);
+    colors[ImGuiCol_CheckMark]          = accent;
+    colors[ImGuiCol_SliderGrab]         = accent;
+    colors[ImGuiCol_SliderGrabActive]   = accent;
 
-    style.WindowRounding = 8.0f;
-    style.FrameRounding = 8.0f;
-    style.GrabRounding = 8.0f;
-    style.ScrollbarRounding = 8.0f;
-    style.FramePadding = ImVec2(12.0f, 8.0f);
-    style.ItemSpacing = ImVec2(10.0f, 10.0f);
-    style.TouchExtraPadding = ImVec2(4.0f, 4.0f);
-    style.ScrollbarSize = 20.0f;
+    style.WindowRounding = 6.0f;
+    style.FrameRounding = 6.0f;
+    style.GrabRounding = 6.0f;
 
     ImPlotStyle& plotStyle = ImPlot::GetStyle();
     plotStyle.Colors[ImPlotCol_Line]          = accent;
@@ -163,18 +152,18 @@ static void ApplyIOSStyle() {
     plotStyle.Colors[ImPlotCol_MarkerFill]    = accent;
     plotStyle.Colors[ImPlotCol_FrameBg]       = surface;
     plotStyle.Colors[ImPlotCol_PlotBg]        = bg;
-    plotStyle.Colors[ImPlotCol_PlotBorder]    = ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
+    plotStyle.Colors[ImPlotCol_PlotBorder]    = dark ? ImVec4(0.3f, 0.3f, 0.3f, 1.0f) : ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     plotStyle.Colors[ImPlotCol_LegendBg]      = surface;
     plotStyle.Colors[ImPlotCol_LegendBorder]  = plotStyle.Colors[ImPlotCol_PlotBorder];
-    plotStyle.Colors[ImPlotCol_LegendText]    = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
-    plotStyle.Colors[ImPlotCol_TitleText]     = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisText]      = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisGrid]      = ImVec4(0.86f, 0.86f, 0.86f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisTick]      = ImVec4(0.86f, 0.86f, 0.86f, 1.0f);
-    plotStyle.Colors[ImPlotCol_AxisBgHovered] = colors[ImGuiCol_ButtonHovered];
-    plotStyle.Colors[ImPlotCol_AxisBgActive]  = colors[ImGuiCol_ButtonActive];
+    plotStyle.Colors[ImPlotCol_LegendText]    = text;
+    plotStyle.Colors[ImPlotCol_TitleText]     = text;
+    plotStyle.Colors[ImPlotCol_AxisText]      = text;
+    plotStyle.Colors[ImPlotCol_AxisGrid]      = plotStyle.Colors[ImPlotCol_PlotBorder];
+    plotStyle.Colors[ImPlotCol_AxisTick]      = plotStyle.Colors[ImPlotCol_PlotBorder];
     plotStyle.Colors[ImPlotCol_Selection]     = ImVec4(accent.x, accent.y, accent.z, 0.25f);
-    plotStyle.Colors[ImPlotCol_Crosshairs]    = ImVec4(0.0f, 0.0f, 0.0f, 0.5f);
+    plotStyle.Colors[ImPlotCol_Crosshairs]    = text;
+
+    clear_color = bg;
 }
 
 int main(int argc, char** argv)
@@ -212,8 +201,9 @@ int main(int argc, char** argv)
     ImGui_ImplSDL2_InitForOpenGL(window, ctx);
     ImGui_ImplOpenGL3_Init(imguiShaderVersions); // Select proper OpenGL version automagically
 
-    ImGui::StyleColorsLight();
-    ApplyIOSStyle();
+    ImVec4 clear_color;
+    bool dark_mode = true;
+    ApplyMaterialTheme(dark_mode, clear_color);
 
     // Load Fonts
     // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
@@ -225,7 +215,6 @@ int main(int argc, char** argv)
 
     bool show_test_window = true;
     bool show_another_window = false;
-    ImVec4 clear_color = ImVec4(0.97f, 0.97f, 0.97f, 1.0f);
 
     std::vector<double> btc_x, btc_prices;
     std::vector<double> eth_x, eth_prices;
@@ -281,6 +270,26 @@ int main(int argc, char** argv)
             ImGui_ImplOpenGL3_NewFrame();
             ImGui_ImplSDL2_NewFrame();
             ImGui::NewFrame();
+
+            if (ImGui::BeginMainMenuBar()) {
+                if (ImGui::BeginMenu("Theme")) {
+                    if (ImGui::MenuItem("Dark", NULL, dark_mode)) {
+                        if (!dark_mode) {
+                            dark_mode = true;
+                            ApplyMaterialTheme(true, clear_color);
+                        }
+                    }
+                    if (ImGui::MenuItem("Light", NULL, !dark_mode)) {
+                        if (dark_mode) {
+                            dark_mode = false;
+                            ApplyMaterialTheme(false, clear_color);
+                        }
+                    }
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMainMenuBar();
+            }
+
             // 1. Show a simple window
             // Tip: if we don't call ImGui::Begin()/ImGui::End() the widgets appears in a window automatically called "Debug"
             {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Imgui_Android
 A demo of dear imgui running on Android.
 
-The demo now uses a Material-inspired dark theme so the interface feels at home on modern Android.
+The demo now uses an iOS-inspired light theme with touch-friendly spacing for a modern mobile feel.
 ![screenshot](https://raw.githubusercontent.com/sfalexrog/Imgui_Android/master/screenshot/screenshot.png)
 
 The running build number is displayed in the corner for quick version identification.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Imgui_Android
 A demo of dear imgui running on Android.
 
-The demo now uses an iOS-inspired light theme with touch-friendly spacing for a modern mobile feel.
+The demo now ships with a Material-inspired theme featuring a bright accent color. A theme menu lets you switch between light and dark styles at runtime.
 ![screenshot](https://raw.githubusercontent.com/sfalexrog/Imgui_Android/master/screenshot/screenshot.png)
 
 The running build number is displayed in the corner for quick version identification.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Imgui_Android
-A demo of dear imgui running on Android
+A demo of dear imgui running on Android.
+
+The demo now uses a Material-inspired dark theme so the interface feels at home on modern Android.
 ![screenshot](https://raw.githubusercontent.com/sfalexrog/Imgui_Android/master/screenshot/screenshot.png)
 
 The running build number is displayed in the corner for quick version identification.


### PR DESCRIPTION
## Summary
- style ImGui and ImPlot with a Material-inspired dark theme
- document Material theme in the README

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04ae5645883208e6becd0029109f9