### PR TITLE
Add touch-friendly Material theme with slide-out settings toggle

### DIFF
--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -106,7 +106,97 @@ static SDL_GLContext createCtx(SDL_Window *w)
     return ctx;
 }
 
+static bool ToggleSwitch(const char* label, bool* v) {
+    ImVec2 p = ImGui::GetCursorScreenPos();
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    float height = ImGui::GetFrameHeight();
+    float width = height * 1.6f;
+    float radius = height * 0.5f;
+    std::string id = std::string("##") + label;
+    ImGui::InvisibleButton(id.c_str(), ImVec2(width, height));
+    bool toggled = false;
+    if (ImGui::IsItemClicked()) {
+        *v = !*v;
+        toggled = true;
+    }
+    ImU32 col_bg = *v ? ImGui::GetColorU32(ImGuiCol_Button) : ImGui::GetColorU32(ImGuiCol_FrameBg);
+    if (ImGui::IsItemHovered())
+        col_bg = *v ? ImGui::GetColorU32(ImGuiCol_ButtonHovered) : ImGui::GetColorU32(ImGuiCol_FrameBgHovered);
+    draw_list->AddRectFilled(p, ImVec2(p.x + width, p.y + height), col_bg, radius);
+    draw_list->AddCircleFilled(ImVec2(*v ? p.x + width - radius : p.x + radius, p.y + radius), radius - 1.5f, IM_COL32(255, 255, 255, 255));
+    ImGui::SameLine();
+    ImGui::TextUnformatted(label);
+    return toggled;
+}
 
+static void ApplyMaterialTheme(bool dark, ImVec4& clear_color, float scale) {
+    ImGuiStyle& style = ImGui::GetStyle();
+    ImVec4* colors = style.Colors;
+    ImVec4 accent = dark ? ImVec4(0.73f, 0.53f, 0.99f, 1.0f) : ImVec4(0.26f, 0.47f, 0.96f, 1.0f);
+    ImVec4 bg = dark ? ImVec4(0.12f, 0.12f, 0.12f, 1.0f) : ImVec4(0.95f, 0.95f, 0.95f, 1.0f);
+    ImVec4 surface = dark ? ImVec4(0.18f, 0.18f, 0.18f, 1.0f) : ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    ImVec4 text = dark ? ImVec4(1.0f, 1.0f, 1.0f, 1.0f) : ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+
+    if (dark)
+        ImGui::StyleColorsDark();
+    else
+        ImGui::StyleColorsLight();
+
+    colors[ImGuiCol_Text]               = text;
+    colors[ImGuiCol_WindowBg]           = bg;
+    colors[ImGuiCol_ChildBg]            = bg;
+    colors[ImGuiCol_PopupBg]            = surface;
+    colors[ImGuiCol_FrameBg]            = surface;
+    colors[ImGuiCol_FrameBgHovered]     = ImVec4(accent.x, accent.y, accent.z, 0.4f);
+    colors[ImGuiCol_FrameBgActive]      = ImVec4(accent.x, accent.y, accent.z, 0.6f);
+    colors[ImGuiCol_Button]             = ImVec4(accent.x, accent.y, accent.z, 0.8f);
+    colors[ImGuiCol_ButtonHovered]      = ImVec4(accent.x, accent.y, accent.z, 1.0f);
+    colors[ImGuiCol_ButtonActive]       = ImVec4(accent.x, accent.y, accent.z, 0.6f);
+    colors[ImGuiCol_Header]             = ImVec4(accent.x, accent.y, accent.z, 0.8f);
+    colors[ImGuiCol_HeaderHovered]      = ImVec4(accent.x, accent.y, accent.z, 1.0f);
+    colors[ImGuiCol_HeaderActive]       = ImVec4(accent.x, accent.y, accent.z, 0.6f);
+    colors[ImGuiCol_Tab]                = surface;
+    colors[ImGuiCol_TabHovered]         = colors[ImGuiCol_ButtonHovered];
+    colors[ImGuiCol_TabActive]          = colors[ImGuiCol_ButtonActive];
+    colors[ImGuiCol_TabUnfocused]       = surface;
+    colors[ImGuiCol_TabUnfocusedActive] = colors[ImGuiCol_TabActive];
+    colors[ImGuiCol_CheckMark]          = accent;
+    colors[ImGuiCol_SliderGrab]         = accent;
+    colors[ImGuiCol_SliderGrabActive]   = accent;
+
+    style.WindowRounding = 6.0f;
+    style.FrameRounding = 6.0f;
+    style.GrabRounding = 6.0f;
+    style.FramePadding = ImVec2(12.0f, 8.0f);
+    style.ItemSpacing = ImVec2(8.0f, 12.0f);
+    style.ScrollbarSize = 24.0f;
+    style.GrabMinSize = 20.0f;
+    style.TouchExtraPadding = ImVec2(8.0f, 8.0f);
+    style.ScaleAllSizes(scale);
+
+    ImPlotStyle& plotStyle = ImPlot::GetStyle();
+    plotStyle.Colors[ImPlotCol_Line]          = accent;
+    plotStyle.Colors[ImPlotCol_Fill]          = ImVec4(accent.x, accent.y, accent.z, 0.25f);
+    plotStyle.Colors[ImPlotCol_MarkerOutline] = accent;
+    plotStyle.Colors[ImPlotCol_MarkerFill]    = accent;
+    plotStyle.Colors[ImPlotCol_FrameBg]       = surface;
+    plotStyle.Colors[ImPlotCol_PlotBg]        = bg;
+    plotStyle.Colors[ImPlotCol_PlotBorder]    = dark ? ImVec4(0.3f, 0.3f, 0.3f, 1.0f) : ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
+    plotStyle.Colors[ImPlotCol_LegendBg]      = surface;
+    plotStyle.Colors[ImPlotCol_LegendBorder]  = plotStyle.Colors[ImPlotCol_PlotBorder];
+    plotStyle.Colors[ImPlotCol_LegendText]    = text;
+    plotStyle.Colors[ImPlotCol_TitleText]     = text;
+    plotStyle.Colors[ImPlotCol_AxisText]      = text;
+    plotStyle.Colors[ImPlotCol_AxisGrid]      = plotStyle.Colors[ImPlotCol_PlotBorder];
+    plotStyle.Colors[ImPlotCol_AxisTick]      = plotStyle.Colors[ImPlotCol_PlotBorder];
+    plotStyle.Colors[ImPlotCol_Selection]     = ImVec4(accent.x, accent.y, accent.z, 0.25f);
+    plotStyle.Colors[ImPlotCol_Crosshairs]    = text;
+    plotStyle.LineWeight = 2.0f;
+    plotStyle.MarkerSize = 6.0f;
+    plotStyle.ScaleAllSizes(scale);
+
+    clear_color = bg;
+}
 
 int main(int argc, char** argv)
 {
@@ -143,7 +233,14 @@ int main(int argc, char** argv)
     ImGui_ImplSDL2_InitForOpenGL(window, ctx);
     ImGui_ImplOpenGL3_Init(imguiShaderVersions); // Select proper OpenGL version automagically
 
-    ImGui::StyleColorsDark();
+    int display_w, display_h;
+    SDL_GetWindowSize(window, &display_w, &display_h);
+    float ui_scale = std::max(1.0f, static_cast<float>(display_w) / 1280.0f);
+
+    ImVec4 clear_color;
+    bool dark_mode = true;
+    bool show_settings = false;
+    ApplyMaterialTheme(dark_mode, clear_color, ui_scale);
 
     // Load Fonts
     // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
@@ -151,11 +248,10 @@ int main(int argc, char** argv)
     //io.Fonts->AddFontDefault();
     //io.Fonts->AddFontFromFileTTF("../../extra_fonts/Cousine-Regular.ttf", 15.0f);
     //io.Fonts->AddFontFromFileTTF("../../extra_fonts/DroidSans.ttf", 16.0f);
-    io.Fonts->AddFontFromFileTTF("Roboto-Medium.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("Roboto-Medium.ttf", 32.0f * ui_scale);
 
     bool show_test_window = true;
     bool show_another_window = false;
-    ImVec4 clear_color = ImColor(114, 144, 154);
 
     std::vector<double> btc_x, btc_prices;
     std::vector<double> eth_x, eth_prices;
@@ -211,6 +307,30 @@ int main(int argc, char** argv)
             ImGui_ImplOpenGL3_NewFrame();
             ImGui_ImplSDL2_NewFrame();
             ImGui::NewFrame();
+
+            ImVec2 btn_size(36.0f * ui_scale, 36.0f * ui_scale);
+            ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - btn_size.x - 8.0f, 8.0f), ImGuiCond_Always);
+            ImGui::SetNextWindowSize(btn_size);
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0,0));
+            ImGui::Begin("SettingsButton", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
+            if (ImGui::Button("⚙"))
+                show_settings = !show_settings;
+            ImGui::End();
+            ImGui::PopStyleVar();
+
+            if (show_settings) {
+                float panel_width = 280.0f * ui_scale;
+                ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - panel_width, 0), ImGuiCond_Always);
+                ImGui::SetNextWindowSize(ImVec2(panel_width, io.DisplaySize.y));
+                ImGui::Begin("Settings", &show_settings, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse);
+                ImGui::TextUnformatted("Appearance");
+                ImGui::Separator();
+                if (ToggleSwitch("Dark mode", &dark_mode)) {
+                    ApplyMaterialTheme(dark_mode, clear_color, ui_scale);
+                }
+                ImGui::End();
+            }
+
             // 1. Show a simple window
             // Tip: if we don't call ImGui::Begin()/ImGui::End() the widgets appears in a window automatically called "Debug"
             {

--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -129,6 +129,33 @@ static bool ToggleSwitch(const char* label, bool* v) {
     return toggled;
 }
 
+static void ScalePlotStyle(ImPlotStyle& style, float scale) {
+    style.LineWeight *= scale;
+    style.MarkerSize *= scale;
+    style.MarkerWeight *= scale;
+    style.ErrorBarSize *= scale;
+    style.ErrorBarWeight *= scale;
+    style.DigitalBitHeight *= scale;
+    style.DigitalBitGap *= scale;
+    style.PlotBorderSize *= scale;
+    style.MajorTickLen = ImVec2(style.MajorTickLen.x * scale, style.MajorTickLen.y * scale);
+    style.MinorTickLen = ImVec2(style.MinorTickLen.x * scale, style.MinorTickLen.y * scale);
+    style.MajorTickSize = ImVec2(style.MajorTickSize.x * scale, style.MajorTickSize.y * scale);
+    style.MinorTickSize = ImVec2(style.MinorTickSize.x * scale, style.MinorTickSize.y * scale);
+    style.MajorGridSize = ImVec2(style.MajorGridSize.x * scale, style.MajorGridSize.y * scale);
+    style.MinorGridSize = ImVec2(style.MinorGridSize.x * scale, style.MinorGridSize.y * scale);
+    style.PlotPadding = ImVec2(style.PlotPadding.x * scale, style.PlotPadding.y * scale);
+    style.LabelPadding = ImVec2(style.LabelPadding.x * scale, style.LabelPadding.y * scale);
+    style.LegendPadding = ImVec2(style.LegendPadding.x * scale, style.LegendPadding.y * scale);
+    style.LegendInnerPadding = ImVec2(style.LegendInnerPadding.x * scale, style.LegendInnerPadding.y * scale);
+    style.LegendSpacing = ImVec2(style.LegendSpacing.x * scale, style.LegendSpacing.y * scale);
+    style.MousePosPadding = ImVec2(style.MousePosPadding.x * scale, style.MousePosPadding.y * scale);
+    style.AnnotationPadding = ImVec2(style.AnnotationPadding.x * scale, style.AnnotationPadding.y * scale);
+    style.FitPadding = ImVec2(style.FitPadding.x * scale, style.FitPadding.y * scale);
+    style.PlotDefaultSize = ImVec2(style.PlotDefaultSize.x * scale, style.PlotDefaultSize.y * scale);
+    style.PlotMinSize = ImVec2(style.PlotMinSize.x * scale, style.PlotMinSize.y * scale);
+}
+
 static void ApplyMaterialTheme(bool dark, ImVec4& clear_color, float scale) {
     ImGuiStyle& style = ImGui::GetStyle();
     ImVec4* colors = style.Colors;
@@ -175,6 +202,7 @@ static void ApplyMaterialTheme(bool dark, ImVec4& clear_color, float scale) {
     style.ScaleAllSizes(scale);
 
     ImPlotStyle& plotStyle = ImPlot::GetStyle();
+    ScalePlotStyle(plotStyle, scale);
     plotStyle.Colors[ImPlotCol_Line]          = accent;
     plotStyle.Colors[ImPlotCol_Fill]          = ImVec4(accent.x, accent.y, accent.z, 0.25f);
     plotStyle.Colors[ImPlotCol_MarkerOutline] = accent;
@@ -191,9 +219,9 @@ static void ApplyMaterialTheme(bool dark, ImVec4& clear_color, float scale) {
     plotStyle.Colors[ImPlotCol_AxisTick]      = plotStyle.Colors[ImPlotCol_PlotBorder];
     plotStyle.Colors[ImPlotCol_Selection]     = ImVec4(accent.x, accent.y, accent.z, 0.25f);
     plotStyle.Colors[ImPlotCol_Crosshairs]    = text;
-    plotStyle.LineWeight = 2.0f;
-    plotStyle.MarkerSize = 6.0f;
-    plotStyle.ScaleAllSizes(scale);
+    plotStyle.LineWeight = 2.0f * scale;
+    plotStyle.MarkerSize = 6.0f * scale;
+    plotStyle.MarkerWeight = 1.0f * scale;
 
     clear_color = bg;
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Imgui_Android
-A demo of dear imgui running on Android
+A demo of dear imgui running on Android.
+
+The demo now ships with a Material-inspired theme featuring distinct light and dark accent colors and touch-friendly spacing that scales with screen size. A slide-out settings panel provides a modern toggle to switch themes at runtime.
 ![screenshot](https://raw.githubusercontent.com/sfalexrog/Imgui_Android/master/screenshot/screenshot.png)
 
 The running build number is displayed in the corner for quick version identification.


### PR DESCRIPTION
## Summary
- refine Material theme with distinct light and dark accent colors
- add slide-out settings panel with toggle switch for theme
- document new settings panel and accents in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04ae5645883208e6becd0029109f9