### PR TITLE
Require OpenSSL and Internet permission for WebSockets

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
 
+      - name: Install OpenSSL libraries
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
 
+      - name: Install OpenSSL libraries
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/ImguiDemoSdl/src/main/AndroidManifest.xml
+++ b/ImguiDemoSdl/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-feature android:glEsVersion="0x00020000" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -13,6 +13,33 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(SDL2 REQUIRED)
 
+# Locate OpenSSL libraries for the target architecture
+if(ANDROID)
+    if(CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
+        set(_openssl_triple "aarch64-linux-android")
+    elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "armeabi-v7a")
+        set(_openssl_triple "arm-linux-androideabi")
+    elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "x86")
+        set(_openssl_triple "i686-linux-android")
+    elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "x86_64")
+        set(_openssl_triple "x86_64-linux-android")
+    endif()
+
+    # Determine API level for sysroot search path
+    if(DEFINED CMAKE_SYSTEM_VERSION)
+        set(_openssl_api "${CMAKE_SYSTEM_VERSION}")
+    else()
+        set(_openssl_api "21")
+    endif()
+
+    set(_openssl_path "${CMAKE_SYSROOT}/usr/lib/${_openssl_triple}/${_openssl_api}")
+    find_library(SSL_LIBRARY NAMES ssl PATHS ${_openssl_path} NO_DEFAULT_PATH REQUIRED)
+    find_library(CRYPTO_LIBRARY NAMES crypto PATHS ${_openssl_path} NO_DEFAULT_PATH REQUIRED)
+else()
+    find_library(SSL_LIBRARY ssl REQUIRED)
+    find_library(CRYPTO_LIBRARY crypto REQUIRED)
+endif()
+
 # This is an adaptation of the ImGui demo showcasing ImPlot for rendering plots.
 
 set(IMGUI_PATH deps/imgui)
@@ -87,18 +114,9 @@ endif()
 
 set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
-find_library(SSL_LIB ssl)
-find_library(CRYPTO_LIB crypto)
-
-set(OPTIONAL_SSL_LIBS)
-if (SSL_LIB AND CRYPTO_LIB)
-    list(APPEND OPTIONAL_SSL_LIBS ${SSL_LIB} ${CRYPTO_LIB})
-    target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
-else()
-    message(WARNING "SSL libraries not found; secure WebSocket connections disabled")
-endif()
-
-target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 ${OPTIONAL_SSL_LIBS})
+target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
+# Link against OpenSSL for secure WebSocket support
+target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} ${SSL_LIBRARY} ${CRYPTO_LIBRARY})
 target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient)
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, and Android-specific cmake in order to build this demo. Good thing is, you only really need the
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL development libraries in order to build this demo. Good thing is, you only really need the
 SDK and NDK parts, gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
@@ -42,6 +42,10 @@ and accept the licenses. If you don't have an NDK, run
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager ndk-bundle
 
 This will download the latest NDK and put it into `${ANDROID_SDK_ROOT}/ndk-bundle`.
+
+For secure WebSocket connections, ensure the OpenSSL headers are installed, for example:
+
+    sudo apt install libssl-dev
 
 Then, download the project and its submodules:
 


### PR DESCRIPTION
## Summary
- fix OpenSSL discovery on Android by including API level in sysroot search path
- enforce linking against libssl and libcrypto for secure WebSocket streaming
- grant Internet permission in the Android manifest
- install OpenSSL dev libs in CI workflows and document the requirement
- discover OpenSSL in CMake and include headers so native build finds ssl.h
- resolve OpenSSL libraries from the Android platform for native builds
- map Android ABIs to NDK sysroot to locate libssl and libcrypto

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f8138db08320a4ef64e59fba59ef