### PR TITLE
Enable TLS for WebSocket connections

### DIFF
--- a/ImguiDemoSdl/src/main/AndroidManifest.xml
+++ b/ImguiDemoSdl/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="me.sfalexrog.imguidemo">
 
     <uses-feature android:glEsVersion="0x00020000" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -87,18 +87,11 @@ endif()
 
 set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
-find_library(SSL_LIB ssl)
-find_library(CRYPTO_LIB crypto)
+find_library(SSL_LIB ssl REQUIRED)
+find_library(CRYPTO_LIB crypto REQUIRED)
 
-set(OPTIONAL_SSL_LIBS)
-if (SSL_LIB AND CRYPTO_LIB)
-    list(APPEND OPTIONAL_SSL_LIBS ${SSL_LIB} ${CRYPTO_LIB})
-    target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
-else()
-    message(WARNING "SSL libraries not found; secure WebSocket connections disabled")
-endif()
-
-target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 ${OPTIONAL_SSL_LIBS})
+target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
+target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 ${SSL_LIB} ${CRYPTO_LIB})
 target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient)
 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ tell me why if it isn't!), but it seems to work.
 ### Android
 
 You'll need OpenJDK 1.8, Android SDK, NDK, and Android-specific cmake in order to build this demo. Good thing is, you only really need the
+For secure WebSocket (wss) support, ensure OpenSSL libraries (libssl and libcrypto) are installed; on Debian-based systems this can be done with `sudo apt-get install libssl-dev`.
 SDK and NDK parts, gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses


### PR DESCRIPTION
## Summary
- require OpenSSL and link TLS libraries for secure WebSocket support
- allow network access for price updates in the Android manifest
- document OpenSSL dependency for secure WebSocket builds

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a98f289ef083209f1d6f231c3d143d