### PR TITLE
Add secure websocket debugging and network configuration

### DIFF
--- a/ImguiDemoSdl/src/main/AndroidManifest.xml
+++ b/ImguiDemoSdl/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     package="me.sfalexrog.imguidemo">
 
     <uses-feature android:glEsVersion="0x00020000" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(SDL2 REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBWEBSOCKETS REQUIRED libwebsockets)
+find_package(OpenSSL REQUIRED)
 
 # This is an adaptation of the ImGui demo, with some geometry (a teapot)
 # rendered in order to check the ImGui implementation. Teapot is taken
@@ -62,9 +65,10 @@ else()
     )
 endif()
 
-target_link_libraries(demo ${SDL2_LIBRARY} glm GLESv2)
+target_link_libraries(demo ${SDL2_LIBRARY} glm GLESv2 ${LIBWEBSOCKETS_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto)
 target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR})
 target_include_directories(demo PRIVATE ${IMGUI_PATH})
 target_include_directories(demo PRIVATE ${IMGUI_IMPL_PATH})
 target_include_directories(demo PRIVATE ${GLLOAD_PATH})
+target_include_directories(demo PRIVATE ${LIBWEBSOCKETS_INCLUDE_DIRS})
 target_compile_definitions(demo PRIVATE ${GL_PROFILES})

--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -12,6 +12,7 @@
 #include "imgui_impl_sdl_gl3.h"
 #endif
 #include "teapot.h"
+#include "websocket_client.h"
 
 #include <unistd.h>
 #include <dirent.h>
@@ -162,6 +163,7 @@ int main(int argc, char** argv)
     bool show_another_window = false;
     ImVec4 clear_color = ImColor(114, 144, 154);
 
+    WebSocketClient wsClient;
     Log(LOG_INFO) << "Entering main loop";
     {
 
@@ -255,6 +257,29 @@ int main(int argc, char** argv)
                 ImGui::SliderFloat("Teapot rotation", &teapotRotation, 0, 2 * M_PI);
                 ImGui::Checkbox("Rotate synchronously", &rotateSync);
                 ImGui::Text("Zoom value: %f", teapot.zoomValue());
+                ImGui::End();
+            }
+
+            // 5. WebSocket debug window
+            {
+                ImGui::Begin("WebSocket Debug");
+                static char url[256] = "echo.websocket.events";
+                ImGui::InputText("URL", url, IM_ARRAYSIZE(url));
+                WSState wsState = wsClient.state();
+                if (wsState == WSState::DISCONNECTED && ImGui::Button("Connect"))
+                    wsClient.connect(url);
+                if (wsState == WSState::CONNECTED && ImGui::Button("Disconnect"))
+                    wsClient.disconnect();
+                const char* stateStr = "Unknown";
+                switch (wsState) {
+                    case WSState::DISCONNECTED: stateStr = "Disconnected"; break;
+                    case WSState::CONNECTING: stateStr = "Connecting"; break;
+                    case WSState::CONNECTED: stateStr = "Connected"; break;
+                    case WSState::ERROR: stateStr = "Error"; break;
+                }
+                ImGui::Text("State: %s", stateStr);
+                for (const auto& line : wsClient.logs())
+                    ImGui::TextUnformatted(line.c_str());
                 ImGui::End();
             }
 

--- a/ImguiDemoSdl/src/main/cpp/src/websocket_client.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/websocket_client.cpp
@@ -1,0 +1,140 @@
+#include "websocket_client.h"
+#include "logger.h"
+
+WebSocketClient::WebSocketClient()
+    : context_(nullptr), wsi_(nullptr), state_(WSState::DISCONNECTED), running_(false) {}
+
+WebSocketClient::~WebSocketClient() {
+    disconnect();
+}
+
+void WebSocketClient::connect(const std::string &url) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (state_ == WSState::CONNECTING || state_ == WSState::CONNECTED)
+        return;
+    url_ = url;
+    state_ = WSState::CONNECTING;
+    running_ = true;
+    thread_ = std::thread(&WebSocketClient::run, this);
+}
+
+void WebSocketClient::disconnect() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        running_ = false;
+    }
+    if (thread_.joinable())
+        thread_.join();
+    if (context_) {
+        lws_context_destroy(context_);
+        context_ = nullptr;
+    }
+    wsi_ = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        state_ = WSState::DISCONNECTED;
+    }
+}
+
+WSState WebSocketClient::state() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return state_;
+}
+
+std::vector<std::string> WebSocketClient::logs() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return logs_;
+}
+
+int WebSocketClient::callback(struct lws *wsi, enum lws_callback_reasons reason,
+                              void *user, void *in, size_t len) {
+    WebSocketClient *self = reinterpret_cast<WebSocketClient *>(lws_context_user(lws_get_context(wsi)));
+    switch (reason) {
+        case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
+            if (self) {
+                std::lock_guard<std::mutex> lock(self->mutex_);
+                self->logs_.push_back("Connection error");
+                self->state_ = WSState::ERROR;
+            }
+            break;
+        case LWS_CALLBACK_CLIENT_ESTABLISHED:
+            if (self) {
+                std::lock_guard<std::mutex> lock(self->mutex_);
+                self->logs_.push_back("Connected");
+                self->state_ = WSState::CONNECTED;
+            }
+            break;
+        case LWS_CALLBACK_CLOSED:
+            if (self) {
+                std::lock_guard<std::mutex> lock(self->mutex_);
+                self->logs_.push_back("Disconnected");
+                self->state_ = WSState::DISCONNECTED;
+            }
+            break;
+        case LWS_CALLBACK_CLIENT_RECEIVE:
+            if (self) {
+                std::string msg(static_cast<const char *>(in), len);
+                std::lock_guard<std::mutex> lock(self->mutex_);
+                self->logs_.push_back("Recv: " + msg);
+            }
+            break;
+        default:
+            break;
+    }
+    return 0;
+}
+
+void WebSocketClient::run() {
+    lws_protocols protocols[] = {
+        {"ws", WebSocketClient::callback, 0, 0},
+        {nullptr, nullptr, 0, 0}
+    };
+
+    lws_context_creation_info info = {};
+    info.port = CONTEXT_PORT_NO_LISTEN;
+    info.protocols = protocols;
+    info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+    info.user = this;
+    info.fd_limit_per_thread = 1 + 1;
+
+    context_ = lws_create_context(&info);
+    if (!context_) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        logs_.push_back("Failed to create context");
+        state_ = WSState::ERROR;
+        running_ = false;
+        return;
+    }
+
+    std::string address = url_;
+    std::string path = "/";
+    auto pos = address.find('/');
+    if (pos != std::string::npos) {
+        path = address.substr(pos);
+        address = address.substr(0, pos);
+    }
+
+    lws_client_connect_info ccinfo = {};
+    ccinfo.context = context_;
+    ccinfo.address = address.c_str();
+    ccinfo.port = 443;
+    ccinfo.path = path.c_str();
+    ccinfo.host = address.c_str();
+    ccinfo.origin = "origin";
+    ccinfo.protocol = protocols[0].name;
+    ccinfo.ssl_connection = LCCSCF_USE_SSL;
+
+    wsi_ = lws_client_connect_via_info(&ccinfo);
+    if (!wsi_) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        logs_.push_back("Failed to initiate connection");
+        state_ = WSState::ERROR;
+        running_ = false;
+        return;
+    }
+
+    while (running_) {
+        lws_service(context_, 100);
+    }
+}
+

--- a/ImguiDemoSdl/src/main/cpp/src/websocket_client.h
+++ b/ImguiDemoSdl/src/main/cpp/src/websocket_client.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <thread>
+#include <mutex>
+
+#include <libwebsockets.h>
+
+enum class WSState { DISCONNECTED, CONNECTING, CONNECTED, ERROR };
+
+class WebSocketClient {
+public:
+    WebSocketClient();
+    ~WebSocketClient();
+
+    void connect(const std::string &url);
+    void disconnect();
+
+    WSState state() const;
+    std::vector<std::string> logs() const;
+
+private:
+    static int callback(struct lws *wsi, enum lws_callback_reasons reason,
+                        void *user, void *in, size_t len);
+    void run();
+
+    struct lws_context *context_;
+    struct lws *wsi_;
+    std::thread thread_;
+    std::string url_;
+    mutable std::mutex mutex_;
+    WSState state_;
+    std::vector<std::string> logs_;
+    bool running_;
+};
+


### PR DESCRIPTION
## Summary
- enable internet and network state permissions in the Android manifest
- integrate libwebsockets with OpenSSL and add a debug window for secure WebSocket connections
- link libwebsockets and OpenSSL in CMake

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew assembleDebug` *(fails: NoClassDefFoundError for org.codehaus.groovy.vmplugin.v7.Java7)*

------
https://chatgpt.com/codex/tasks/task_e_68a9980215d883209b25ca1ad1a8b988