### PR TITLE
Enable secure WebSockets and install TLS deps in CI

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,32 +29,21 @@ jobs:
         run: |
           OPENSSL_VERSION=1.1.1w
           curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export ANDROID_NDK=$ANDROID_NDK_HOME
+          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
           API=19
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a)
-                TARGET=android-arm
-                HOST=armv7a-linux-androideabi
-                ;;
-              arm64-v8a)
-                TARGET=android-arm64
-                HOST=aarch64-linux-android
-                ;;
-              x86)
-                TARGET=android-x86
-                HOST=i686-linux-android
-                ;;
-              x86_64)
-                TARGET=android-x86_64
-                HOST=x86_64-linux-android
-                ;;
+              armeabi-v7a) TARGET=android-arm ;;
+              arm64-v8a) TARGET=android-arm64 ;;
+              x86) TARGET=android-x86 ;;
+              x86_64) TARGET=android-x86_64 ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION
             make clean || true
-            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
             make -j$(nproc)
             make install_sw
             popd

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,12 +23,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
-      - name: Restore OpenSSL cache
-        id: openssl-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/openssl
-          key: ${{ runner.os }}-openssl-1.1.1w
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -51,36 +45,6 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
-      - name: Build OpenSSL
-        if: steps.openssl-cache.outputs.cache-hit != 'true'
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
-          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          API=21
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a) TARGET=android-arm;   HOST=armv7a-linux-androideabi ;;
-              arm64-v8a)   TARGET=android-arm64; HOST=aarch64-linux-android ;;
-              x86)         TARGET=android-x86;  HOST=i686-linux-android ;;
-              x86_64)      TARGET=android-x86_64; HOST=x86_64-linux-android ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API \
-              CC=${HOST}${API}-clang AR=llvm-ar RANLIB=llvm-ranlib NM=llvm-nm
-            make -j$(nproc)
-            make install_sw
-            make clean
-            popd
-          done
-      - name: Use cached OpenSSL
-        if: steps.openssl-cache.outputs.cache-hit == 'true'
-        run: echo "Using cached OpenSSL"
-      - name: Export OpenSSL root
-        run: echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,29 +14,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build OpenSSL for Android
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a) TARGET=android-arm ;;
-              arm64-v8a) TARGET=android-arm64 ;;
-              x86) TARGET=android-x86 ;;
-              x86_64) TARGET=android-x86_64 ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI
-            make -j$(nproc)
-            make install_sw
-            popd
-          done
-          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
-          echo "CFLAGS=-I$HOME/openssl/\${ANDROID_ABI}/include" >> $GITHUB_ENV
-          echo "LDFLAGS=-L$HOME/openssl/\${ANDROID_ABI}/lib" >> $GITHUB_ENV
-
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -47,6 +24,30 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
+
+      - name: Build OpenSSL for Android
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          API=19
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm ;; HOST=armv7a-linux-androideabi ;;
+              arm64-v8a) TARGET=android-arm64 ;; HOST=aarch64-linux-android ;;
+              x86) TARGET=android-x86 ;; HOST=i686-linux-android ;;
+              x86_64) TARGET=android-x86_64 ;; HOST=x86_64-linux-android ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,55 +25,14 @@ jobs:
         with:
           packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
 
-      - name: Build OpenSSL for Android
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export ANDROID_NDK=$ANDROID_NDK_HOME
-          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a)
-                TARGET=android-arm
-                HOST=armv7a-linux-androideabi
-                API=19
-                ;;
-              arm64-v8a)
-                TARGET=android-arm64
-                HOST=aarch64-linux-android
-                API=21
-                ;;
-              x86)
-                TARGET=android-x86
-                HOST=i686-linux-android
-                API=19
-                ;;
-              x86_64)
-                TARGET=android-x86_64
-                HOST=x86_64-linux-android
-                API=21
-                ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
-            make -j$(nproc)
-            make install_sw
-            popd
-          done
-          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Configure SDK, NDK, and OpenSSL paths
+      - name: Configure SDK and NDK paths
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "openssl.dir=$HOME/openssl" >> local.properties
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,27 +32,31 @@ jobs:
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
+          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build OpenSSL
         run: |
           OPENSSL_VERSION=1.1.1w
           curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
+          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          API=21
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi ;;
-              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android ;;
-              x86) TARGET=android-x86; HOST=i686-linux-android ;;
-              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android ;;
+              armeabi-v7a) TARGET=android-arm;   HOST=armv7a-linux-androideabi ;;
+              arm64-v8a)   TARGET=android-arm64; HOST=aarch64-linux-android ;;
+              x86)         TARGET=android-x86;  HOST=i686-linux-android ;;
+              x86_64)      TARGET=android-x86_64; HOST=x86_64-linux-android ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            CC=${HOST}21-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=21
+            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API \
+              CC=${HOST}${API}-clang AR=llvm-ar RANLIB=llvm-ranlib NM=llvm-nm
             make -j$(nproc)
             make install_sw
+            make clean
             popd
           done
           echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,18 +32,33 @@ jobs:
           export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
           export ANDROID_NDK=$ANDROID_NDK_HOME
           export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          API=19
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a) TARGET=android-arm ;;
-              arm64-v8a) TARGET=android-arm64 ;;
-              x86) TARGET=android-x86 ;;
-              x86_64) TARGET=android-x86_64 ;;
+              armeabi-v7a)
+                TARGET=android-arm
+                HOST=armv7a-linux-androideabi
+                API=19
+                ;;
+              arm64-v8a)
+                TARGET=android-arm64
+                HOST=aarch64-linux-android
+                API=21
+                ;;
+              x86)
+                TARGET=android-x86
+                HOST=i686-linux-android
+                API=19
+                ;;
+              x86_64)
+                TARGET=android-x86_64
+                HOST=x86_64-linux-android
+                API=21
+                ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION
             make clean || true
-            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
             make -j$(nproc)
             make install_sw
             popd

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Configure SDK and NDK paths
+      - name: Configure SDK, NDK, and OpenSSL paths
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "OPENSSL_ROOT_DIR=/usr" >> $GITHUB_ENV
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -45,31 +45,6 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
-
-      - name: Build OpenSSL
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi; API=19 ;;
-              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android; API=21 ;;
-              x86) TARGET=android-x86; HOST=i686-linux-android; API=19 ;;
-              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android; API=21 ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
-            make -j$(nproc)
-            make install_sw
-            popd
-          done
-          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
-          echo "openssl.dir=$HOME/openssl" >> local.properties
-
       - name: Build debug APK
         run: ./gradlew assembleDebug
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Configure SDK and NDK paths
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
-          echo "ndk.dir=$ANDROID_NDK_ROOT" >> local.properties
+          echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,6 +14,22 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Restore OpenSSL cache
+        id: openssl-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/openssl
+          key: ${{ runner.os }}-openssl-1.1.1w
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -36,6 +52,7 @@ jobs:
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build OpenSSL
+        if: steps.openssl-cache.outputs.cache-hit != 'true'
         run: |
           OPENSSL_VERSION=1.1.1w
           curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
@@ -59,7 +76,11 @@ jobs:
             make clean
             popd
           done
-          echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
+      - name: Use cached OpenSSL
+        if: steps.openssl-cache.outputs.cache-hit == 'true'
+        run: echo "Using cached OpenSSL"
+      - name: Export OpenSSL root
+        run: echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,10 +34,22 @@ jobs:
           API=19
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a) TARGET=android-arm ;; HOST=armv7a-linux-androideabi ;;
-              arm64-v8a) TARGET=android-arm64 ;; HOST=aarch64-linux-android ;;
-              x86) TARGET=android-x86 ;; HOST=i686-linux-android ;;
-              x86_64) TARGET=android-x86_64 ;; HOST=x86_64-linux-android ;;
+              armeabi-v7a)
+                TARGET=android-arm
+                HOST=armv7a-linux-androideabi
+                ;;
+              arm64-v8a)
+                TARGET=android-arm64
+                HOST=aarch64-linux-android
+                ;;
+              x86)
+                TARGET=android-x86
+                HOST=i686-linux-android
+                ;;
+              x86_64)
+                TARGET=android-x86_64
+                HOST=x86_64-linux-android
+                ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -36,7 +36,6 @@ jobs:
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "OPENSSL_ROOT_DIR=/usr" >> $GITHUB_ENV
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -46,6 +46,30 @@ jobs:
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
 
+      - name: Build OpenSSL
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi; API=19 ;;
+              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android; API=21 ;;
+              x86) TARGET=android-x86; HOST=i686-linux-android; API=19 ;;
+              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android; API=21 ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
+          echo "openssl.dir=$HOME/openssl" >> local.properties
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,8 +14,28 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install TLS libraries
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+      - name: Build OpenSSL for Android
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm ;;
+              arm64-v8a) TARGET=android-arm64 ;;
+              x86) TARGET=android-x86 ;;
+              x86_64) TARGET=android-x86_64 ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
+          echo "CFLAGS=-I$HOME/openssl/\${ANDROID_ABI}/include" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$HOME/openssl/\${ANDROID_ABI}/lib" >> $GITHUB_ENV
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -36,6 +56,7 @@ jobs:
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "openssl.dir=$HOME/openssl" >> local.properties
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install TLS libraries
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -28,8 +31,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Configure SDK path
-        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+      - name: Configure SDK and NDK paths
+        run: |
+          echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+          echo "ndk.dir=$ANDROID_NDK_ROOT" >> local.properties
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,6 +34,29 @@ jobs:
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
+      - name: Build OpenSSL
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi ;;
+              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android ;;
+              x86) TARGET=android-x86; HOST=i686-linux-android ;;
+              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            CC=${HOST}21-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=21
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "OPENSSL_ROOT_DIR=/usr" >> $GITHUB_ENV
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,29 @@ jobs:
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
+      - name: Build OpenSSL
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi ;;
+              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android ;;
+              x86) TARGET=android-x86; HOST=i686-linux-android ;;
+              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            CC=${HOST}21-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=21
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
+
       - name: Build release APK
         run: ./gradlew assembleRelease
       - name: Rename APK with run number and timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,22 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Restore OpenSSL cache
+        id: openssl-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/openssl
+          key: ${{ runner.os }}-openssl-1.1.1w
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -38,6 +54,7 @@ jobs:
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build OpenSSL
+        if: steps.openssl-cache.outputs.cache-hit != 'true'
         run: |
           OPENSSL_VERSION=1.1.1w
           curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
@@ -61,7 +78,11 @@ jobs:
             make clean
             popd
           done
-          echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
+      - name: Use cached OpenSSL
+        if: steps.openssl-cache.outputs.cache-hit == 'true'
+        run: echo "Using cached OpenSSL"
+      - name: Export OpenSSL root
+        run: echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Configure SDK and NDK paths
+      - name: Configure SDK, NDK, and OpenSSL paths
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "OPENSSL_ROOT_DIR=/usr" >> $GITHUB_ENV
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Configure SDK and NDK paths
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
-          echo "ndk.dir=$ANDROID_NDK_ROOT" >> local.properties
+          echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,22 @@ jobs:
           API=19
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a) TARGET=android-arm ;; HOST=armv7a-linux-androideabi ;;
-              arm64-v8a) TARGET=android-arm64 ;; HOST=aarch64-linux-android ;;
-              x86) TARGET=android-x86 ;; HOST=i686-linux-android ;;
-              x86_64) TARGET=android-x86_64 ;; HOST=x86_64-linux-android ;;
+              armeabi-v7a)
+                TARGET=android-arm
+                HOST=armv7a-linux-androideabi
+                ;;
+              arm64-v8a)
+                TARGET=android-arm64
+                HOST=aarch64-linux-android
+                ;;
+              x86)
+                TARGET=android-x86
+                HOST=i686-linux-android
+                ;;
+              x86_64)
+                TARGET=android-x86_64
+                HOST=x86_64-linux-android
+                ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,55 +27,14 @@ jobs:
         with:
           packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
 
-      - name: Build OpenSSL for Android
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export ANDROID_NDK=$ANDROID_NDK_HOME
-          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a)
-                TARGET=android-arm
-                HOST=armv7a-linux-androideabi
-                API=19
-                ;;
-              arm64-v8a)
-                TARGET=android-arm64
-                HOST=aarch64-linux-android
-                API=21
-                ;;
-              x86)
-                TARGET=android-x86
-                HOST=i686-linux-android
-                API=19
-                ;;
-              x86_64)
-                TARGET=android-x86_64
-                HOST=x86_64-linux-android
-                API=21
-                ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
-            make -j$(nproc)
-            make install_sw
-            popd
-          done
-          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Configure SDK, NDK, and OpenSSL paths
+      - name: Configure SDK and NDK paths
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "openssl.dir=$HOME/openssl" >> local.properties
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,28 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install TLS libraries
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+      - name: Build OpenSSL for Android
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm ;;
+              arm64-v8a) TARGET=android-arm64 ;;
+              x86) TARGET=android-x86 ;;
+              x86_64) TARGET=android-x86_64 ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
+          echo "CFLAGS=-I$HOME/openssl/\${ANDROID_ABI}/include" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$HOME/openssl/\${ANDROID_ABI}/lib" >> $GITHUB_ENV
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -38,6 +58,7 @@ jobs:
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "openssl.dir=$HOME/openssl" >> local.properties
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
-      - name: Restore OpenSSL cache
-        id: openssl-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/openssl
-          key: ${{ runner.os }}-openssl-1.1.1w
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -53,36 +47,6 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
-      - name: Build OpenSSL
-        if: steps.openssl-cache.outputs.cache-hit != 'true'
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
-          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          API=21
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a) TARGET=android-arm;   HOST=armv7a-linux-androideabi ;;
-              arm64-v8a)   TARGET=android-arm64; HOST=aarch64-linux-android ;;
-              x86)         TARGET=android-x86;  HOST=i686-linux-android ;;
-              x86_64)      TARGET=android-x86_64; HOST=x86_64-linux-android ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API \
-              CC=${HOST}${API}-clang AR=llvm-ar RANLIB=llvm-ranlib NM=llvm-nm
-            make -j$(nproc)
-            make install_sw
-            make clean
-            popd
-          done
-      - name: Use cached OpenSSL
-        if: steps.openssl-cache.outputs.cache-hit == 'true'
-        run: echo "Using cached OpenSSL"
-      - name: Export OpenSSL root
-        run: echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,30 @@ jobs:
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
 
+      - name: Build OpenSSL
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi; API=19 ;;
+              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android; API=21 ;;
+              x86) TARGET=android-x86; HOST=i686-linux-android; API=19 ;;
+              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android; API=21 ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
+          echo "openssl.dir=$HOME/openssl" >> local.properties
+
       - name: Build release APK
         run: ./gradlew assembleRelease
       - name: Rename APK with run number and timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,32 +31,21 @@ jobs:
         run: |
           OPENSSL_VERSION=1.1.1w
           curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export ANDROID_NDK=$ANDROID_NDK_HOME
+          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
           API=19
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a)
-                TARGET=android-arm
-                HOST=armv7a-linux-androideabi
-                ;;
-              arm64-v8a)
-                TARGET=android-arm64
-                HOST=aarch64-linux-android
-                ;;
-              x86)
-                TARGET=android-x86
-                HOST=i686-linux-android
-                ;;
-              x86_64)
-                TARGET=android-x86_64
-                HOST=x86_64-linux-android
-                ;;
+              armeabi-v7a) TARGET=android-arm ;;
+              arm64-v8a) TARGET=android-arm64 ;;
+              x86) TARGET=android-x86 ;;
+              x86_64) TARGET=android-x86_64 ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION
             make clean || true
-            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
             make -j$(nproc)
             make install_sw
             popd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install TLS libraries
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -30,8 +33,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Configure SDK path
-        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+      - name: Configure SDK and NDK paths
+        run: |
+          echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+          echo "ndk.dir=$ANDROID_NDK_ROOT" >> local.properties
 
       - name: Build release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,29 +16,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build OpenSSL for Android
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a) TARGET=android-arm ;;
-              arm64-v8a) TARGET=android-arm64 ;;
-              x86) TARGET=android-x86 ;;
-              x86_64) TARGET=android-x86_64 ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI
-            make -j$(nproc)
-            make install_sw
-            popd
-          done
-          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
-          echo "CFLAGS=-I$HOME/openssl/\${ANDROID_ABI}/include" >> $GITHUB_ENV
-          echo "LDFLAGS=-L$HOME/openssl/\${ANDROID_ABI}/lib" >> $GITHUB_ENV
-
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -49,6 +26,30 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0 cmake;3.22.1 ndk;25.2.9519653'
+
+      - name: Build OpenSSL for Android
+        run: |
+          OPENSSL_VERSION=1.1.1w
+          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
+          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          API=19
+          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
+            case $ABI in
+              armeabi-v7a) TARGET=android-arm ;; HOST=armv7a-linux-androideabi ;;
+              arm64-v8a) TARGET=android-arm64 ;; HOST=aarch64-linux-android ;;
+              x86) TARGET=android-x86 ;; HOST=i686-linux-android ;;
+              x86_64) TARGET=android-x86_64 ;; HOST=x86_64-linux-android ;;
+            esac
+            mkdir -p $HOME/openssl/$ABI
+            pushd openssl-$OPENSSL_VERSION
+            make clean || true
+            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            make -j$(nproc)
+            make install_sw
+            popd
+          done
+          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,31 +47,6 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
-
-      - name: Build OpenSSL
-        run: |
-          OPENSSL_VERSION=1.1.1w
-          curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case $ABI in
-              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi; API=19 ;;
-              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android; API=21 ;;
-              x86) TARGET=android-x86; HOST=i686-linux-android; API=19 ;;
-              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android; API=21 ;;
-            esac
-            mkdir -p $HOME/openssl/$ABI
-            pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
-            make -j$(nproc)
-            make install_sw
-            popd
-          done
-          echo "OPENSSL_ROOT_DIR=$HOME/openssl" >> $GITHUB_ENV
-          echo "openssl.dir=$HOME/openssl" >> local.properties
-
       - name: Build release APK
         run: ./gradlew assembleRelease
       - name: Rename APK with run number and timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,27 +34,31 @@ jobs:
         run: |
           echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
           echo "ndk.dir=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> local.properties
+          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build OpenSSL
         run: |
           OPENSSL_VERSION=1.1.1w
           curl -sL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar xz
-          export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
-          export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+          export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
+          export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          API=21
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a) TARGET=android-arm; HOST=armv7a-linux-androideabi ;;
-              arm64-v8a) TARGET=android-arm64; HOST=aarch64-linux-android ;;
-              x86) TARGET=android-x86; HOST=i686-linux-android ;;
-              x86_64) TARGET=android-x86_64; HOST=x86_64-linux-android ;;
+              armeabi-v7a) TARGET=android-arm;   HOST=armv7a-linux-androideabi ;;
+              arm64-v8a)   TARGET=android-arm64; HOST=aarch64-linux-android ;;
+              x86)         TARGET=android-x86;  HOST=i686-linux-android ;;
+              x86_64)      TARGET=android-x86_64; HOST=x86_64-linux-android ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION
-            make clean || true
-            CC=${HOST}21-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=21
+            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API \
+              CC=${HOST}${API}-clang AR=llvm-ar RANLIB=llvm-ranlib NM=llvm-nm
             make -j$(nproc)
             make install_sw
+            make clean
             popd
           done
           echo "OPENSSL_ROOT=$HOME/openssl" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,18 +34,33 @@ jobs:
           export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653
           export ANDROID_NDK=$ANDROID_NDK_HOME
           export PATH="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-          API=19
           for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
             case $ABI in
-              armeabi-v7a) TARGET=android-arm ;;
-              arm64-v8a) TARGET=android-arm64 ;;
-              x86) TARGET=android-x86 ;;
-              x86_64) TARGET=android-x86_64 ;;
+              armeabi-v7a)
+                TARGET=android-arm
+                HOST=armv7a-linux-androideabi
+                API=19
+                ;;
+              arm64-v8a)
+                TARGET=android-arm64
+                HOST=aarch64-linux-android
+                API=21
+                ;;
+              x86)
+                TARGET=android-x86
+                HOST=i686-linux-android
+                API=19
+                ;;
+              x86_64)
+                TARGET=android-x86_64
+                HOST=x86_64-linux-android
+                API=21
+                ;;
             esac
             mkdir -p $HOME/openssl/$ABI
             pushd openssl-$OPENSSL_VERSION
             make clean || true
-            ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
+            CC=${HOST}${API}-clang ./Configure $TARGET no-shared --prefix=$HOME/openssl/$ABI -D__ANDROID_API__=$API
             make -j$(nproc)
             make install_sw
             popd

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 ## Environment
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
-- Rely on the NDK's bundled TLS libraries (`ssl` and `crypto`); ensure `minSdkVersion` is 21 or higher so they are available.
+- Build OpenSSL for each Android ABI and expose its base directory via the `OPENSSL_ROOT` environment variable or `openssl.dir` in `local.properties`.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
 - Export `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts can locate the toolchain.
-- Android's NDK ships BoringSSL, so no external OpenSSL build is required for TLS support.
+- Build OpenSSL for each Android ABI and set `OPENSSL_ROOT_DIR` or `openssl.dir` so TLS headers and libraries are available during native builds.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Ensure the NDK path in `local.properties` matches `android.ndkVersion` to avoid version conflicts.
 - Export `ANDROID_SDK_ROOT` and `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts and CI workflows can locate the toolchains consistently.
 - Link against the NDK's bundled TLS libraries (BoringSSL); if TLS libraries are reported missing, fix the environment instead of disabling secure WebSockets.
+- Include BoringSSL headers from `${ANDROID_NDK}/sources/third_party/openssl/include` so native code can find `openssl/ssl.h`.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,15 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Use `rg` for searching the codebase and avoid `ls -R` or `grep -R`.
 - Follow the existing code style for Kotlin, C++, and build scripts.
 - Keep commits focused and easy to review with clear, imperative messages (e.g., `Add feature X`).
+- Once a technical direction is chosen (e.g., using the NDK's BoringSSL for TLS), do not switch to alternative stacks unless explicitly requested by maintainers.
+- Investigate and resolve build or CI failures immediately rather than committing temporary workarounds.
 
 ## Environment
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
-- Export `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts can locate the toolchain.
-- Link against the NDK's bundled TLS libraries (BoringSSL); no external OpenSSL build is required.
+- Ensure the NDK path in `local.properties` matches `android.ndkVersion` to avoid version conflicts.
+- Export `ANDROID_SDK_ROOT` and `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts and CI workflows can locate the toolchains consistently.
+- Link against the NDK's bundled TLS libraries (BoringSSL); if TLS libraries are reported missing, fix the environment instead of disabling secure WebSockets.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
 - Export `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts can locate the toolchain.
-- Build OpenSSL for each Android ABI and expose its base directory via the `OPENSSL_ROOT` environment variable or `openssl.dir` in `local.properties`.
+- Android's NDK ships BoringSSL, so no external OpenSSL build is required for TLS support.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
 - Export `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts can locate the toolchain.
-- Build OpenSSL for each Android ABI and set `OPENSSL_ROOT_DIR` or `openssl.dir` so TLS headers and libraries are available during native builds.
+- Link against the NDK's bundled TLS libraries (BoringSSL); no external OpenSSL build is required.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Use `rg` for searching the codebase and avoid `ls -R` or `grep -R`.
 - Follow the existing code style for Kotlin, C++, and build scripts.
 - Keep commits focused and easy to review with clear, imperative messages (e.g., `Add feature X`).
-- Once a technical direction is chosen (e.g., using the NDK's BoringSSL for TLS), do not switch to alternative stacks unless explicitly requested by maintainers.
+- Once a technical direction is chosen (e.g., using mbedTLS for TLS), do not switch to alternative stacks unless explicitly requested by maintainers.
 - Investigate and resolve build or CI failures immediately rather than committing temporary workarounds.
 
 ## Environment
@@ -17,8 +17,8 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Use NDK version `25.2.9519653` for builds.
 - Ensure the NDK path in `local.properties` matches `android.ndkVersion` to avoid version conflicts.
 - Export `ANDROID_SDK_ROOT` and `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts and CI workflows can locate the toolchains consistently.
-- Link against the NDK's bundled TLS libraries (BoringSSL); if TLS libraries are reported missing, fix the environment instead of disabling secure WebSockets.
-- Include BoringSSL headers from `${ANDROID_NDK}/sources/third_party/openssl/include` so native code can find `openssl/ssl.h`.
+- Use mbedTLS for secure WebSockets. The build fetches and links against mbedTLS; avoid adding OpenSSL or BoringSSL dependencies unless maintainers request otherwise.
+- Ensure mbedTLS headers are discoverable by the build system so native code can include the appropriate `mbedtls` headers.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 ## Environment
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
-- Provide `OPENSSL_ROOT_DIR` pointing to per-ABI `include` and `lib` directories so TLS libraries can be located.
+- Rely on the NDK's bundled TLS libraries (`ssl` and `crypto`); ensure `minSdkVersion` is 21 or higher so they are available.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,17 @@
 These instructions apply to the entire repository unless a more specific `AGENTS.md` exists in a subdirectory.
 
 ## Workflow
-- Ensure your branch is up to date with the target branch by rebasing or merging before making changes and again before committing or submitting a PR to avoid merge conflicts when multiple PRs are in progress.
+- Check for `AGENTS.md` files in any directories you touch and follow their instructions.
+- Ensure your branch is up to date with the target branch before and after making changes to avoid conflicts.
+- Use `rg` for searching the codebase and avoid `ls -R` or `grep -R`.
 - Follow the existing code style for Kotlin, C++, and build scripts.
-- Keep commits focused and easy to review.
-- Use clear, imperative commit messages (e.g., `Add feature X`).
+- Keep commits focused and easy to review with clear, imperative messages (e.g., `Add feature X`).
+
+## Environment
+- Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
+- Use NDK version `25.2.9519653` for builds.
+- Provide `OPENSSL_ROOT_DIR` pointing to per-ABI `include` and `lib` directories so TLS libraries can be located.
+- The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing
 - Run `./gradlew test` before committing to execute unit tests and basic checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 - Export `ANDROID_SDK_ROOT` and `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts and CI workflows can locate the toolchains consistently.
 - Use mbedTLS for secure WebSockets. The build fetches and links against mbedTLS; avoid adding OpenSSL or BoringSSL dependencies unless maintainers request otherwise.
 - Ensure mbedTLS headers are discoverable by the build system so native code can include the appropriate `mbedtls` headers.
+- The project uses a custom `mbedtls_config.h` that disables AES-NI for portability across Android ABIs; keep this file in sync with build scripts.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 ## Environment
 - Install the Android SDK and NDK and set `sdk.dir` and `ndk.dir` in `local.properties`.
 - Use NDK version `25.2.9519653` for builds.
+- Export `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` so build scripts can locate the toolchain.
 - Build OpenSSL for each Android ABI and expose its base directory via the `OPENSSL_ROOT` environment variable or `openssl.dir` in `local.properties`.
 - The demo relies on `network_security_config.xml` and Internet permissions for secure WebSocket connections; keep these enabled.
 

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -46,6 +46,9 @@ android {
                 cFlags "-std=c11"
                 cppFlags "-std=c++11"
                 arguments "-DANDROID_PLATFORM=android-21"
+                if (opensslRoot != null) {
+                    arguments "-DOPENSSL_ROOT=${opensslRoot}"
+                }
             }
         }
     }
@@ -59,9 +62,6 @@ android {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
             version "3.22.1"
-            if (opensslRoot != null) {
-                arguments "-DOPENSSL_ROOT=${opensslRoot}"
-            }
         }
     }
 

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -38,8 +38,7 @@ android {
             cmake {
                 cFlags "-std=c11"
                 cppFlags "-std=c++11"
-                arguments "-DANDROID_PLATFORM=android-21",
-                        "-DOPENSSL_BASE=${System.getenv('OPENSSL_ROOT_DIR') ?: project.findProperty('openssl.dir')}"
+                arguments "-DANDROID_PLATFORM=android-21"
             }
         }
     }

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -29,7 +29,7 @@ android {
 //    buildToolsVersion "30.0.2"
     defaultConfig {
         applicationId "me.sfalexrog.imguidemo"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode versionCodeValue
         versionName "1.0"

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -38,8 +38,8 @@ android {
             cmake {
                 cFlags "-std=c11"
                 cppFlags "-std=c++11"
-                arguments "-DANDROID_PLATFORM=android-21"
-                // Android's NDK provides BoringSSL; no external OpenSSL needed
+                arguments "-DANDROID_PLATFORM=android-21",
+                        "-DOPENSSL_BASE=${System.getenv('OPENSSL_ROOT_DIR') ?: project.findProperty('openssl.dir')}"
             }
         }
     }

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -38,6 +38,7 @@ android {
             cmake {
                 cFlags "-std=c11"
                 cppFlags "-std=c++11"
+                arguments "-DANDROID_PLATFORM=android-21"
             }
         }
     }

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -22,13 +22,6 @@ if (shouldIncrement) {
     versionProps.store(new FileOutputStream(versionPropsFile), null)
 }
 
-def localProps = new Properties()
-def localPropsFile = rootProject.file("local.properties")
-if (localPropsFile.exists()) {
-    localProps.load(new FileInputStream(localPropsFile))
-}
-def opensslRoot = System.getenv("OPENSSL_ROOT") ?: localProps.getProperty("openssl.dir")
-
 android {
     namespace = "me.sfalexrog.imguidemo"
     compileSdkVersion 34
@@ -46,9 +39,7 @@ android {
                 cFlags "-std=c11"
                 cppFlags "-std=c++11"
                 arguments "-DANDROID_PLATFORM=android-21"
-                if (opensslRoot != null) {
-                    arguments "-DOPENSSL_ROOT=${opensslRoot}"
-                }
+                // Android's NDK provides BoringSSL; no external OpenSSL needed
             }
         }
     }

--- a/ImguiDemoSdl/build.gradle
+++ b/ImguiDemoSdl/build.gradle
@@ -22,6 +22,13 @@ if (shouldIncrement) {
     versionProps.store(new FileOutputStream(versionPropsFile), null)
 }
 
+def localProps = new Properties()
+def localPropsFile = rootProject.file("local.properties")
+if (localPropsFile.exists()) {
+    localProps.load(new FileInputStream(localPropsFile))
+}
+def opensslRoot = System.getenv("OPENSSL_ROOT") ?: localProps.getProperty("openssl.dir")
+
 android {
     namespace = "me.sfalexrog.imguidemo"
     compileSdkVersion 34
@@ -52,6 +59,9 @@ android {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
             version "3.22.1"
+            if (opensslRoot != null) {
+                arguments "-DOPENSSL_ROOT=${opensslRoot}"
+            }
         }
     }
 

--- a/ImguiDemoSdl/src/main/AndroidManifest.xml
+++ b/ImguiDemoSdl/src/main/AndroidManifest.xml
@@ -3,9 +3,12 @@
     package="me.sfalexrog.imguidemo">
 
     <uses-feature android:glEsVersion="0x00020000" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"
+        android:usesCleartextTraffic="false"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,15 +90,10 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if(ANDROID)
-    find_library(SSL_LIB ssl)
-    find_library(CRYPTO_LIB crypto)
-    if(NOT SSL_LIB OR NOT CRYPTO_LIB)
-        message(FATAL_ERROR "TLS libraries not found; secure WebSocket connections disabled")
-    endif()
     target_link_libraries(demo PRIVATE
             ${SDL2_LIBRARY}
-            ${SSL_LIB}
-            ${CRYPTO_LIB})
+            ssl
+            crypto)
 else()
     find_package(OpenSSL REQUIRED)
     target_link_libraries(demo PRIVATE

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,19 +90,15 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if(ANDROID)
-    # Use the NDK's bundled BoringSSL headers and stub libraries
-    set(BORINGSSL_INCLUDE_DIR "$ENV{ANDROID_NDK}/sources/third_party/openssl/include")
+    # Use the NDK's bundled BoringSSL headers and link directly against the
+    # provided stub libraries. CMake's Android toolchain exposes these
+    # libraries via the sysroot so we can reference them by name.
+    set(BORINGSSL_INCLUDE_DIR "${ANDROID_NDK}/sources/third_party/openssl/include")
     target_include_directories(demo PRIVATE ${BORINGSSL_INCLUDE_DIR})
-    find_library(SSL_LIB ssl)
-    find_library(CRYPTO_LIB crypto)
-    if(SSL_LIB AND CRYPTO_LIB)
-        target_link_libraries(demo PRIVATE
-                ${SDL2_LIBRARY}
-                ${SSL_LIB}
-                ${CRYPTO_LIB})
-    else()
-        message(FATAL_ERROR "TLS libraries not found; secure WebSocket connections require NDK ssl and crypto stubs")
-    endif()
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            ssl
+            crypto)
 else()
     find_package(OpenSSL REQUIRED)
     target_link_libraries(demo PRIVATE

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -89,30 +89,29 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
-if (ANDROID)
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            GLESv2
-            ssl
-            crypto)
-    target_include_directories(demo PRIVATE
-            ${SDL2_INCLUDE_DIR}
-            deps/implot
-            deps
-            deps/easywsclient)
-else()
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            OpenSSL::SSL
-            OpenSSL::Crypto)
-    target_include_directories(demo PRIVATE
-            ${SDL2_INCLUDE_DIR}
-            deps/implot
-            deps
-            deps/easywsclient
-            ${OPENSSL_INCLUDE_DIR})
+if(ANDROID)
+    if(DEFINED OPENSSL_ROOT)
+        set(OPENSSL_ROOT_DIR "${OPENSSL_ROOT}/${ANDROID_ABI}")
+    elseif(DEFINED ENV{OPENSSL_ROOT})
+        set(OPENSSL_ROOT_DIR "$ENV{OPENSSL_ROOT}/${ANDROID_ABI}")
+    else()
+        message(FATAL_ERROR "OpenSSL root not specified; set OPENSSL_ROOT in Gradle or the environment")
+    endif()
+    set(OPENSSL_USE_STATIC_LIBS ON)
 endif()
+
+find_package(OpenSSL REQUIRED)
+
+target_link_libraries(demo PRIVATE
+        ${SDL2_LIBRARY}
+        OpenSSL::SSL
+        OpenSSL::Crypto)
+
+target_include_directories(demo PRIVATE
+        ${SDL2_INCLUDE_DIR}
+        deps/implot
+        deps
+        deps/easywsclient)
 
 
 

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -89,15 +89,31 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
+find_package(OpenSSL REQUIRED)
+
 if (ANDROID)
-    find_library(SSL_LIB ssl REQUIRED)
-    find_library(CRYPTO_LIB crypto REQUIRED)
-    target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 ${SSL_LIB} ${CRYPTO_LIB})
-    target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient)
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            GLESv2
+            OpenSSL::SSL
+            OpenSSL::Crypto)
+    target_include_directories(demo PRIVATE
+            ${SDL2_INCLUDE_DIR}
+            deps/implot
+            deps
+            deps/easywsclient
+            ${OPENSSL_INCLUDE_DIR})
 else()
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} OpenSSL::SSL OpenSSL::Crypto)
-    target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient ${OPENSSL_INCLUDE_DIR})
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            OpenSSL::SSL
+            OpenSSL::Crypto)
+    target_include_directories(demo PRIVATE
+            ${SDL2_INCLUDE_DIR}
+            deps/implot
+            deps
+            deps/easywsclient
+            ${OPENSSL_INCLUDE_DIR})
 endif()
 
 

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,22 +90,17 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if(ANDROID)
-    if(DEFINED OPENSSL_ROOT)
-        set(OPENSSL_ROOT_DIR "${OPENSSL_ROOT}/${ANDROID_ABI}")
-    elseif(DEFINED ENV{OPENSSL_ROOT})
-        set(OPENSSL_ROOT_DIR "$ENV{OPENSSL_ROOT}/${ANDROID_ABI}")
-    else()
-        message(FATAL_ERROR "OpenSSL root not specified; set OPENSSL_ROOT in Gradle or the environment")
-    endif()
-    set(OPENSSL_USE_STATIC_LIBS ON)
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            ssl
+            crypto)
+else()
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            OpenSSL::SSL
+            OpenSSL::Crypto)
 endif()
-
-find_package(OpenSSL REQUIRED)
-
-target_link_libraries(demo PRIVATE
-        ${SDL2_LIBRARY}
-        OpenSSL::SSL
-        OpenSSL::Crypto)
 
 target_include_directories(demo PRIVATE
         ${SDL2_INCLUDE_DIR}

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -87,10 +87,18 @@ endif()
 
 set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
-find_package(OpenSSL REQUIRED)
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
-target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 OpenSSL::SSL OpenSSL::Crypto)
-target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient ${OPENSSL_INCLUDE_DIR})
+
+if (ANDROID)
+    find_library(SSL_LIB ssl REQUIRED)
+    find_library(CRYPTO_LIB crypto REQUIRED)
+    target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 ${SSL_LIB} ${CRYPTO_LIB})
+    target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient)
+else()
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} OpenSSL::SSL OpenSSL::Crypto)
+    target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient ${OPENSSL_INCLUDE_DIR})
+endif()
 
 
 

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -89,21 +89,26 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
-find_package(OpenSSL REQUIRED)
-
 if (ANDROID)
+    set(OPENSSL_ROOT "$ENV{OPENSSL_ROOT_DIR}/${ANDROID_ABI}")
+    find_library(SSL_LIB ssl HINTS ${OPENSSL_ROOT}/lib NO_CMAKE_SYSTEM_PATH)
+    find_library(CRYPTO_LIB crypto HINTS ${OPENSSL_ROOT}/lib NO_CMAKE_SYSTEM_PATH)
+    if (NOT SSL_LIB OR NOT CRYPTO_LIB)
+        message(FATAL_ERROR "OpenSSL libraries not found; secure WebSocket connections disabled")
+    endif()
     target_link_libraries(demo PRIVATE
             ${SDL2_LIBRARY}
             GLESv2
-            OpenSSL::SSL
-            OpenSSL::Crypto)
+            ${SSL_LIB}
+            ${CRYPTO_LIB})
     target_include_directories(demo PRIVATE
             ${SDL2_INCLUDE_DIR}
             deps/implot
             deps
             deps/easywsclient
-            ${OPENSSL_INCLUDE_DIR})
+            ${OPENSSL_ROOT}/include)
 else()
+    find_package(OpenSSL REQUIRED)
     target_link_libraries(demo PRIVATE
             ${SDL2_LIBRARY}
             OpenSSL::SSL

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -87,19 +87,10 @@ endif()
 
 set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
-find_library(SSL_LIB ssl)
-find_library(CRYPTO_LIB crypto)
-
-set(OPTIONAL_SSL_LIBS)
-if (SSL_LIB AND CRYPTO_LIB)
-    list(APPEND OPTIONAL_SSL_LIBS ${SSL_LIB} ${CRYPTO_LIB})
-    target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
-else()
-    message(WARNING "SSL libraries not found; secure WebSocket connections disabled")
-endif()
-
-target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 ${OPTIONAL_SSL_LIBS})
-target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient)
+find_package(OpenSSL REQUIRED)
+target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
+target_link_libraries(demo PRIVATE ${SDL2_LIBRARY} GLESv2 OpenSSL::SSL OpenSSL::Crypto)
+target_include_directories(demo PRIVATE ${SDL2_INCLUDE_DIR} deps/implot deps deps/easywsclient ${OPENSSL_INCLUDE_DIR})
 
 
 

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,17 +90,16 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if(ANDROID)
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            ssl
-            crypto)
-else()
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            OpenSSL::SSL
-            OpenSSL::Crypto)
+    if(NOT DEFINED OPENSSL_BASE)
+        message(FATAL_ERROR "OPENSSL_BASE not set; please provide path with per-ABI OpenSSL builds")
+    endif()
+    set(OPENSSL_ROOT_DIR "${OPENSSL_BASE}/${ANDROID_ABI}")
 endif()
+find_package(OpenSSL REQUIRED)
+target_link_libraries(demo PRIVATE
+        ${SDL2_LIBRARY}
+        OpenSSL::SSL
+        OpenSSL::Crypto)
 
 target_include_directories(demo PRIVATE
         ${SDL2_INCLUDE_DIR}

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -91,6 +91,7 @@ target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 # Fetch and link against mbedTLS for secure WebSockets
 include(FetchContent)
+set(MBEDTLS_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls_config.h")
 FetchContent_Declare(
     mbedtls
     URL https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.5.1.tar.gz

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,16 +90,11 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if (ANDROID)
-    find_library(SSL_LIB NAMES ssl)
-    find_library(CRYPTO_LIB NAMES crypto)
-    if (NOT SSL_LIB OR NOT CRYPTO_LIB)
-        message(FATAL_ERROR "TLS libraries not found; secure WebSocket connections disabled")
-    endif()
     target_link_libraries(demo PRIVATE
             ${SDL2_LIBRARY}
             GLESv2
-            ${SSL_LIB}
-            ${CRYPTO_LIB})
+            ssl
+            crypto)
     target_include_directories(demo PRIVATE
             ${SDL2_INCLUDE_DIR}
             deps/implot

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,16 +90,22 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if(ANDROID)
-    if(NOT DEFINED OPENSSL_BASE)
-        message(FATAL_ERROR "OPENSSL_BASE not set; please provide path with per-ABI OpenSSL builds")
+    find_library(SSL_LIB ssl)
+    find_library(CRYPTO_LIB crypto)
+    if(NOT SSL_LIB OR NOT CRYPTO_LIB)
+        message(FATAL_ERROR "TLS libraries not found; secure WebSocket connections disabled")
     endif()
-    set(OPENSSL_ROOT_DIR "${OPENSSL_BASE}/${ANDROID_ABI}")
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            ${SSL_LIB}
+            ${CRYPTO_LIB})
+else()
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(demo PRIVATE
+            ${SDL2_LIBRARY}
+            OpenSSL::SSL
+            OpenSSL::Crypto)
 endif()
-find_package(OpenSSL REQUIRED)
-target_link_libraries(demo PRIVATE
-        ${SDL2_LIBRARY}
-        OpenSSL::SSL
-        OpenSSL::Crypto)
 
 target_include_directories(demo PRIVATE
         ${SDL2_INCLUDE_DIR}

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,10 +90,19 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if(ANDROID)
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            ssl
-            crypto)
+    # Use the NDK's bundled BoringSSL headers and stub libraries
+    set(BORINGSSL_INCLUDE_DIR "$ENV{ANDROID_NDK}/sources/third_party/openssl/include")
+    target_include_directories(demo PRIVATE ${BORINGSSL_INCLUDE_DIR})
+    find_library(SSL_LIB ssl)
+    find_library(CRYPTO_LIB crypto)
+    if(SSL_LIB AND CRYPTO_LIB)
+        target_link_libraries(demo PRIVATE
+                ${SDL2_LIBRARY}
+                ${SSL_LIB}
+                ${CRYPTO_LIB})
+    else()
+        message(FATAL_ERROR "TLS libraries not found; secure WebSocket connections require NDK ssl and crypto stubs")
+    endif()
 else()
     find_package(OpenSSL REQUIRED)
     target_link_libraries(demo PRIVATE

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -90,11 +90,10 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
 if (ANDROID)
-    set(OPENSSL_ROOT "$ENV{OPENSSL_ROOT_DIR}/${ANDROID_ABI}")
-    find_library(SSL_LIB ssl HINTS ${OPENSSL_ROOT}/lib NO_CMAKE_SYSTEM_PATH)
-    find_library(CRYPTO_LIB crypto HINTS ${OPENSSL_ROOT}/lib NO_CMAKE_SYSTEM_PATH)
+    find_library(SSL_LIB NAMES ssl)
+    find_library(CRYPTO_LIB NAMES crypto)
     if (NOT SSL_LIB OR NOT CRYPTO_LIB)
-        message(FATAL_ERROR "OpenSSL libraries not found; secure WebSocket connections disabled")
+        message(FATAL_ERROR "TLS libraries not found; secure WebSocket connections disabled")
     endif()
     target_link_libraries(demo PRIVATE
             ${SDL2_LIBRARY}
@@ -105,8 +104,7 @@ if (ANDROID)
             ${SDL2_INCLUDE_DIR}
             deps/implot
             deps
-            deps/easywsclient
-            ${OPENSSL_ROOT}/include)
+            deps/easywsclient)
 else()
     find_package(OpenSSL REQUIRED)
     target_link_libraries(demo PRIVATE

--- a/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
+++ b/ImguiDemoSdl/src/main/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 # be the same throughout platforms.
 
 # target_link_options appeared in 3.13, and is extremely recommended for Android builds
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14)
 
 project(imgui_demo)
 
@@ -89,23 +89,19 @@ set(DEMO_SOURCES ${IMGUI_FILES} ${DEMO_FILES} ${GLLOAD_FILES})
 
 target_compile_definitions(demo PRIVATE EASYWSCLIENT_ENABLE_SSL)
 
-if(ANDROID)
-    # Use the NDK's bundled BoringSSL headers and link directly against the
-    # provided stub libraries. CMake's Android toolchain exposes these
-    # libraries via the sysroot so we can reference them by name.
-    set(BORINGSSL_INCLUDE_DIR "${ANDROID_NDK}/sources/third_party/openssl/include")
-    target_include_directories(demo PRIVATE ${BORINGSSL_INCLUDE_DIR})
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            ssl
-            crypto)
-else()
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(demo PRIVATE
-            ${SDL2_LIBRARY}
-            OpenSSL::SSL
-            OpenSSL::Crypto)
-endif()
+# Fetch and link against mbedTLS for secure WebSockets
+include(FetchContent)
+FetchContent_Declare(
+    mbedtls
+    URL https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.5.1.tar.gz
+)
+FetchContent_MakeAvailable(mbedtls)
+
+target_link_libraries(demo PRIVATE
+        ${SDL2_LIBRARY}
+        mbedtls
+        mbedcrypto
+        mbedx509)
 
 target_include_directories(demo PRIVATE
         ${SDL2_INCLUDE_DIR}

--- a/ImguiDemoSdl/src/main/cpp/deps/easywsclient/easywsclient.cpp
+++ b/ImguiDemoSdl/src/main/cpp/deps/easywsclient/easywsclient.cpp
@@ -74,8 +74,10 @@
 #include <string>
 
 #ifdef EASYWSCLIENT_ENABLE_SSL
-#include <openssl/ssl.h>
-#include <openssl/err.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
 #endif
 #include "easywsclient.hpp"
 
@@ -83,6 +85,29 @@ using easywsclient::Callback_Imp;
 using easywsclient::BytesCallback_Imp;
 
 namespace { // private module-only namespace
+
+#ifdef EASYWSCLIENT_ENABLE_SSL
+struct TLSContext {
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_context entropy;
+    mbedtls_net_context net;
+    TLSContext() {
+        mbedtls_ssl_init(&ssl);
+        mbedtls_ssl_config_init(&conf);
+        mbedtls_ctr_drbg_init(&ctr_drbg);
+        mbedtls_entropy_init(&entropy);
+        mbedtls_net_init(&net);
+    }
+    ~TLSContext() {
+        mbedtls_ssl_free(&ssl);
+        mbedtls_ssl_config_free(&conf);
+        mbedtls_ctr_drbg_free(&ctr_drbg);
+        mbedtls_entropy_free(&entropy);
+    }
+};
+#endif
 
 socket_t hostname_connect(const std::string& hostname, int port) {
     struct addrinfo hints;
@@ -179,13 +204,12 @@ class _RealWebSocket : public easywsclient::WebSocket
     bool useMask;
     bool isRxBad;
 #ifdef EASYWSCLIENT_ENABLE_SSL
-    SSL_CTX* ssl_ctx;
-    SSL* ssl;
+    TLSContext* tls;
 #endif
 
     _RealWebSocket(socket_t sockfd, bool useMask
 #ifdef EASYWSCLIENT_ENABLE_SSL
-            , SSL_CTX* ssl_ctx = NULL, SSL* ssl = NULL
+            , TLSContext* tls = NULL
 #endif
             )
             : sockfd(sockfd)
@@ -193,22 +217,17 @@ class _RealWebSocket : public easywsclient::WebSocket
             , useMask(useMask)
             , isRxBad(false)
 #ifdef EASYWSCLIENT_ENABLE_SSL
-            , ssl_ctx(ssl_ctx)
-            , ssl(ssl)
+            , tls(tls)
 #endif
             {
     }
 
     virtual ~_RealWebSocket() {
 #ifdef EASYWSCLIENT_ENABLE_SSL
-        if (ssl) {
-            SSL_shutdown(ssl);
-            SSL_free(ssl);
-            ssl = NULL;
-        }
-        if (ssl_ctx) {
-            SSL_CTX_free(ssl_ctx);
-            ssl_ctx = NULL;
+        if (tls) {
+            mbedtls_ssl_close_notify(&tls->ssl);
+            delete tls;
+            tls = NULL;
         }
 #endif
         closesocket(sockfd);
@@ -216,11 +235,10 @@ class _RealWebSocket : public easywsclient::WebSocket
 
     ssize_t _recv(char* buf, size_t len) {
 #ifdef EASYWSCLIENT_ENABLE_SSL
-        if (ssl) {
-            int ret = SSL_read(ssl, buf, (int)len);
+        if (tls) {
+            int ret = mbedtls_ssl_read(&tls->ssl, (unsigned char*)buf, len);
             if (ret <= 0) {
-                int err = SSL_get_error(ssl, ret);
-                if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+                if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
                     socketerrno = SOCKET_EWOULDBLOCK;
                 }
                 return -1;
@@ -233,11 +251,10 @@ class _RealWebSocket : public easywsclient::WebSocket
 
     ssize_t _send(const char* buf, size_t len) {
 #ifdef EASYWSCLIENT_ENABLE_SSL
-        if (ssl) {
-            int ret = SSL_write(ssl, buf, (int)len);
+        if (tls) {
+            int ret = mbedtls_ssl_write(&tls->ssl, (const unsigned char*)buf, len);
             if (ret <= 0) {
-                int err = SSL_get_error(ssl, ret);
-                if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+                if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
                     socketerrno = SOCKET_EWOULDBLOCK;
                 }
                 return -1;
@@ -285,7 +302,7 @@ class _RealWebSocket : public easywsclient::WebSocket
                 rxbuf.resize(N);
                 closesocket(sockfd);
 #ifdef EASYWSCLIENT_ENABLE_SSL
-                if (ssl) { SSL_shutdown(ssl); SSL_free(ssl); SSL_CTX_free(ssl_ctx); ssl = NULL; ssl_ctx = NULL; }
+                if (tls) { mbedtls_ssl_close_notify(&tls->ssl); delete tls; tls = NULL; }
 #endif
                 readyState = CLOSED;
                 fputs(ret < 0 ? "Connection error!\n" : "Connection closed!\n", stderr);
@@ -304,7 +321,7 @@ class _RealWebSocket : public easywsclient::WebSocket
             else if (ret <= 0) {
                 closesocket(sockfd);
 #ifdef EASYWSCLIENT_ENABLE_SSL
-                if (ssl) { SSL_shutdown(ssl); SSL_free(ssl); SSL_CTX_free(ssl_ctx); ssl = NULL; ssl_ctx = NULL; }
+                if (tls) { mbedtls_ssl_close_notify(&tls->ssl); delete tls; tls = NULL; }
 #endif
                 readyState = CLOSED;
                 fputs(ret < 0 ? "Connection error!\n" : "Connection closed!\n", stderr);
@@ -317,7 +334,7 @@ class _RealWebSocket : public easywsclient::WebSocket
         if (!txbuf.size() && readyState == CLOSING) {
             closesocket(sockfd);
 #ifdef EASYWSCLIENT_ENABLE_SSL
-            if (ssl) { SSL_shutdown(ssl); SSL_free(ssl); SSL_CTX_free(ssl_ctx); ssl = NULL; ssl_ctx = NULL; }
+            if (tls) { mbedtls_ssl_close_notify(&tls->ssl); delete tls; tls = NULL; }
 #endif
             readyState = CLOSED;
         }
@@ -583,18 +600,35 @@ easywsclient::WebSocket::pointer from_url(const std::string& url, bool useMask, 
     }
 
 #ifdef EASYWSCLIENT_ENABLE_SSL
-    SSL_CTX* ctx = NULL;
-    SSL* ssl = NULL;
+    TLSContext* tls = NULL;
     if (useSSL) {
-        SSL_library_init();
-        SSL_load_error_strings();
-        ctx = SSL_CTX_new(TLS_client_method());
-        if (!ctx) { closesocket(sockfd); return NULL; }
-        ssl = SSL_new(ctx);
-        if (!ssl) { SSL_CTX_free(ctx); closesocket(sockfd); return NULL; }
-        SSL_set_tlsext_host_name(ssl, host);
-        SSL_set_fd(ssl, sockfd);
-        if (SSL_connect(ssl) != 1) { SSL_free(ssl); SSL_CTX_free(ctx); closesocket(sockfd); return NULL; }
+        tls = new TLSContext;
+        const char* pers = "easywsclient";
+        if (mbedtls_ctr_drbg_seed(&tls->ctr_drbg, mbedtls_entropy_func, &tls->entropy,
+                                  (const unsigned char*)pers, strlen(pers)) != 0) {
+            delete tls; closesocket(sockfd); return NULL;
+        }
+        if (mbedtls_ssl_config_defaults(&tls->conf,
+                MBEDTLS_SSL_IS_CLIENT,
+                MBEDTLS_SSL_TRANSPORT_STREAM,
+                MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
+            delete tls; closesocket(sockfd); return NULL;
+        }
+        mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_NONE);
+        mbedtls_ssl_conf_rng(&tls->conf, mbedtls_ctr_drbg_random, &tls->ctr_drbg);
+        if (mbedtls_ssl_setup(&tls->ssl, &tls->conf) != 0) {
+            delete tls; closesocket(sockfd); return NULL;
+        }
+        mbedtls_ssl_set_hostname(&tls->ssl, host);
+        tls->net.fd = sockfd;
+        mbedtls_ssl_set_bio(&tls->ssl, &tls->net, mbedtls_net_send, mbedtls_net_recv, NULL);
+        while (true) {
+            int ret = mbedtls_ssl_handshake(&tls->ssl);
+            if (ret == 0) break;
+            if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+                delete tls; closesocket(sockfd); return NULL;
+            }
+        }
     }
 #else
     if (useSSL) {
@@ -611,13 +645,13 @@ easywsclient::WebSocket::pointer from_url(const std::string& url, bool useMask, 
         int i;
         auto ws_send = [&](const char* data, size_t len){
 #ifdef EASYWSCLIENT_ENABLE_SSL
-            if (useSSL) return SSL_write(ssl, data, (int)len);
+            if (useSSL) return mbedtls_ssl_write(&tls->ssl, (const unsigned char*)data, len);
 #endif
             return (int)::send(sockfd, data, len, 0);
         };
         auto ws_recv = [&](char* data){
 #ifdef EASYWSCLIENT_ENABLE_SSL
-            if (useSSL) return SSL_read(ssl, data, 1);
+            if (useSSL) return mbedtls_ssl_read(&tls->ssl, (unsigned char*)data, 1);
 #endif
             return (int)recv(sockfd, data, 1, 0);
         };
@@ -656,7 +690,7 @@ easywsclient::WebSocket::pointer from_url(const std::string& url, bool useMask, 
 #endif
     //fprintf(stderr, "Connected to: %s\n", url.c_str());
 #ifdef EASYWSCLIENT_ENABLE_SSL
-    return easywsclient::WebSocket::pointer(new _RealWebSocket(sockfd, useMask, useSSL ? ctx : NULL, useSSL ? ssl : NULL));
+    return easywsclient::WebSocket::pointer(new _RealWebSocket(sockfd, useMask, useSSL ? tls : NULL));
 #else
     return easywsclient::WebSocket::pointer(new _RealWebSocket(sockfd, useMask));
 #endif

--- a/ImguiDemoSdl/src/main/cpp/mbedtls_config.h
+++ b/ImguiDemoSdl/src/main/cpp/mbedtls_config.h
@@ -1,0 +1,2 @@
+#include "mbedtls/mbedtls_config.h"
+#undef MBEDTLS_AESNI_C

--- a/ImguiDemoSdl/src/main/cpp/src/main.cpp
+++ b/ImguiDemoSdl/src/main/cpp/src/main.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <deque>
 #include "easywsclient.hpp"
 #include <nlohmann/json.hpp>
 
@@ -221,6 +222,8 @@ int main(int argc, char** argv)
     WebSocket::pointer ws_btc = WebSocket::from_url("wss://stream.binance.com:9443/ws/btcusdt@trade");
     WebSocket::pointer ws_eth = WebSocket::from_url("wss://stream.binance.com:9443/ws/ethusdt@trade");
     const size_t max_points = 1000;
+    std::deque<std::string> ws_log;
+    const size_t max_log = 50;
 
     Log(LOG_INFO) << "Entering main loop";
     {
@@ -239,7 +242,7 @@ int main(int argc, char** argv)
             }
             if (ws_btc) {
                 ws_btc->poll();
-                ws_btc->dispatch([&btc_prices, &btc_x, max_points](const std::string& msg){
+                ws_btc->dispatch([&btc_prices, &btc_x, max_points, &ws_log, max_log](const std::string& msg){
                     try {
                         auto j = nlohmann::json::parse(msg);
                         double price = std::stod(j["p"].get<std::string>());
@@ -249,12 +252,14 @@ int main(int argc, char** argv)
                             btc_prices.erase(btc_prices.begin());
                             btc_x.erase(btc_x.begin());
                         }
+                        ws_log.push_back("BTC: " + std::to_string(price));
+                        if (ws_log.size() > max_log) ws_log.pop_front();
                     } catch (...) {}
                 });
             }
             if (ws_eth) {
                 ws_eth->poll();
-                ws_eth->dispatch([&eth_prices, &eth_x, max_points](const std::string& msg){
+                ws_eth->dispatch([&eth_prices, &eth_x, max_points, &ws_log, max_log](const std::string& msg){
                     try {
                         auto j = nlohmann::json::parse(msg);
                         double price = std::stod(j["p"].get<std::string>());
@@ -264,6 +269,8 @@ int main(int argc, char** argv)
                             eth_prices.erase(eth_prices.begin());
                             eth_x.erase(eth_x.begin());
                         }
+                        ws_log.push_back("ETH: " + std::to_string(price));
+                        if (ws_log.size() > max_log) ws_log.pop_front();
                     } catch (...) {}
                 });
             }
@@ -317,7 +324,15 @@ int main(int argc, char** argv)
                 ImGui::ShowDemoWindow(&show_test_window);
             }
 
-            // 4. Show crypto price plots
+            // 4. Show WebSocket log window
+            if (ImGui::Begin("WebSocket Log")) {
+                for (const auto& entry : ws_log) {
+                    ImGui::TextUnformatted(entry.c_str());
+                }
+            }
+            ImGui::End();
+
+            // 5. Show crypto price plots
             if (ImGui::Begin("Crypto Prices")) {
                 if (ImPlot::BeginPlot("BTC/ETH")) {
                     if (!btc_prices.empty())

--- a/ImguiDemoSdl/src/main/res/xml/network_security_config.xml
+++ b/ImguiDemoSdl/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The demo now ships with a Material-inspired theme featuring a bright accent colo
 ![screenshot](https://raw.githubusercontent.com/sfalexrog/Imgui_Android/master/screenshot/screenshot.png)
 
 The running build number is displayed in the corner for quick version identification.
+Recent WebSocket messages are also visible in a dedicated log window to help with debugging network traffic.
 
 ## What?
 
@@ -32,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. The project targets NDK version 25.2.9519653 (r25c).
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. The project targets NDK version 25.2.9519653 (r25c). Set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
 Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. Good thing is, you only really need the
-SDK and NDK parts, gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. The project targets NDK version 25.2.9519653 (r25c).
+Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
 
 and accept the licenses. If you don't have an NDK, run
 
-    ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager ndk-bundle
+    ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "ndk;25.2.9519653"
 
-This will download the latest NDK and put it into `${ANDROID_SDK_ROOT}/ndk-bundle`. Ensure both `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables are set so Gradle can locate the SDK and NDK.
+This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure both `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables are set, with `ANDROID_NDK_ROOT` pointing to that directory, so Gradle can locate the SDK and matching NDK version.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), Android-specific CMake, and OpenSSL built for each Android ABI so the native code can establish secure WebSocket connections.
+You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), and Android-specific CMake. The native code links against the NDK's bundled TLS libraries (BoringSSL) for secure WebSocket connections, so no extra TLS packages are required.
 
 Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
@@ -43,15 +43,14 @@ and accept the licenses. If you don't have an NDK, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "ndk;25.2.9519653"
 
-This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so Gradle can locate the toolchain. Also set `OPENSSL_ROOT_DIR` to a directory containing per-ABI OpenSSL builds. Create a `local.properties` file (or copy `local.properties.example`) with:
+This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so Gradle can locate the toolchain. Create a `local.properties` file (or copy `local.properties.example`) with:
 
 ```
 sdk.dir=/absolute/path/to/android/sdk
 ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
-openssl.dir=/absolute/path/to/openssl
 ```
 
-Gradle uses these paths to find your SDK, matching NDK installation, and OpenSSL headers/libraries.
+Gradle uses these paths to find your SDK and matching NDK installation.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and accept the licenses. If you don't have an NDK, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "ndk;25.2.9519653"
 
-This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure both `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables are set, with `ANDROID_NDK_ROOT` pointing to that directory, so Gradle can locate the SDK and matching NDK version. Create a `local.properties` file (or copy `local.properties.example`) with:
+This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so both Gradle and the OpenSSL build scripts can locate the toolchain. Create a `local.properties` file (or copy `local.properties.example`) with:
 
 ```
 sdk.dir=/absolute/path/to/android/sdk

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), and Android-specific CMake. The native code links against the NDK's bundled TLS libraries (BoringSSL) for secure WebSocket connections, so no extra TLS packages are required.
+You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), and Android-specific CMake. The native code fetches and links against mbedTLS for secure WebSocket connections, so no extra TLS packages are required.
 
 Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific CMake, and OpenSSL libraries built for Android in order to build this demo with secure WebSocket support. The native build expects `OPENSSL_ROOT_DIR` (and `openssl.dir` in `local.properties`) to point to a directory that contains per-ABI `include` and `lib` subdirectories. For desktop builds set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
+You'll need OpenJDK 1.8, the Android SDK, the NDK, and Android-specific CMake in order to build this demo with secure WebSocket support. TLS is provided by the NDK's bundled `ssl` and `crypto` libraries, which require a minimum API level of 21.
 Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
@@ -47,10 +47,9 @@ This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.951965
 ```
 sdk.dir=/absolute/path/to/android/sdk
 ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
-openssl.dir=/absolute/path/to/prebuilt/openssl
 ```
 
-Gradle uses these paths to find your SDK, NDK, and OpenSSL installation.
+Gradle uses these paths to find your SDK and matching NDK installation.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, the Android SDK, the NDK, and Android-specific CMake in order to build this demo with secure WebSocket support. TLS is provided by the NDK's bundled `ssl` and `crypto` libraries, which require a minimum API level of 21.
-Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
+You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), Android-specific CMake, and OpenSSL built for each Android ABI in order to build this demo with secure WebSocket support. Place the per-ABI OpenSSL installations under a common directory (e.g. `$HOME/openssl/<abi>` for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`) and expose the base path via the `OPENSSL_ROOT` environment variable or an `openssl.dir` entry in `local.properties`.
+
+Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
 
@@ -47,9 +48,10 @@ This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.951965
 ```
 sdk.dir=/absolute/path/to/android/sdk
 ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
+openssl.dir=/absolute/path/to/openssl
 ```
 
-Gradle uses these paths to find your SDK and matching NDK installation.
+Gradle uses these paths to find your SDK, matching NDK, and OpenSSL installation.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), and Android-specific CMake. The NDK ships BoringSSL, so no additional TLS libraries are required for secure WebSocket support.
+You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), Android-specific CMake, and OpenSSL built for each Android ABI so the native code can establish secure WebSocket connections.
 
 Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
@@ -43,14 +43,15 @@ and accept the licenses. If you don't have an NDK, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "ndk;25.2.9519653"
 
-This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so Gradle can locate the toolchain. Create a `local.properties` file (or copy `local.properties.example`) with:
+This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so Gradle can locate the toolchain. Also set `OPENSSL_ROOT_DIR` to a directory containing per-ABI OpenSSL builds. Create a `local.properties` file (or copy `local.properties.example`) with:
 
 ```
 sdk.dir=/absolute/path/to/android/sdk
 ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
+openssl.dir=/absolute/path/to/openssl
 ```
 
-Gradle uses these paths to find your SDK and matching NDK installation.
+Gradle uses these paths to find your SDK, matching NDK installation, and OpenSSL headers/libraries.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), Android-specific CMake, and OpenSSL built for each Android ABI in order to build this demo with secure WebSocket support. Place the per-ABI OpenSSL installations under a common directory (e.g. `$HOME/openssl/<abi>` for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`) and expose the base path via the `OPENSSL_ROOT` environment variable or an `openssl.dir` entry in `local.properties`.
+You'll need OpenJDK 1.8, the Android SDK, the NDK (r25c), and Android-specific CMake. The NDK ships BoringSSL, so no additional TLS libraries are required for secure WebSocket support.
 
 Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
@@ -43,15 +43,14 @@ and accept the licenses. If you don't have an NDK, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "ndk;25.2.9519653"
 
-This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so both Gradle and the OpenSSL build scripts can locate the toolchain. Create a `local.properties` file (or copy `local.properties.example`) with:
+This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` environment variables all point to this NDK directory so Gradle can locate the toolchain. Create a `local.properties` file (or copy `local.properties.example`) with:
 
 ```
 sdk.dir=/absolute/path/to/android/sdk
 ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
-openssl.dir=/absolute/path/to/openssl
 ```
 
-Gradle uses these paths to find your SDK, matching NDK, and OpenSSL installation.
+Gradle uses these paths to find your SDK and matching NDK installation.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. The project targets NDK version 25.2.9519653 (r25c). Set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. Android builds link against the TLS libraries bundled with the NDK, so no extra configuration is required. For desktop builds set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
 Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
@@ -42,7 +42,14 @@ and accept the licenses. If you don't have an NDK, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "ndk;25.2.9519653"
 
-This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure both `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables are set, with `ANDROID_NDK_ROOT` pointing to that directory, so Gradle can locate the SDK and matching NDK version.
+This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.9519653`. Ensure both `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables are set, with `ANDROID_NDK_ROOT` pointing to that directory, so Gradle can locate the SDK and matching NDK version. Create a `local.properties` file (or copy `local.properties.example`) with:
+
+```
+sdk.dir=/absolute/path/to/android/sdk
+ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
+```
+
+Gradle uses these paths to find your SDK and NDK locally.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. Android builds link against the TLS libraries bundled with the NDK, so no extra configuration is required. For desktop builds set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries built for Android in order to build this demo with secure WebSocket support. The native build expects `OPENSSL_ROOT_DIR` to point to a directory that contains per-ABI `include` and `lib` subdirectories. Set `CFLAGS` and `LDFLAGS` to reference these folders if the libraries are not discovered automatically. For desktop builds set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
 Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
@@ -47,9 +47,10 @@ This will download NDK r25c and place it in `${ANDROID_SDK_ROOT}/ndk/25.2.951965
 ```
 sdk.dir=/absolute/path/to/android/sdk
 ndk.dir=/absolute/path/to/android/sdk/ndk/25.2.9519653
+openssl.dir=/absolute/path/to/prebuilt/openssl
 ```
 
-Gradle uses these paths to find your SDK and NDK locally.
+Gradle uses these paths to find your SDK, NDK, and OpenSSL installation.
 
 Then, download the project and its submodules:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries built for Android in order to build this demo with secure WebSocket support. The native build expects `OPENSSL_ROOT_DIR` to point to a directory that contains per-ABI `include` and `lib` subdirectories. Set `CFLAGS` and `LDFLAGS` to reference these folders if the libraries are not discovered automatically. For desktop builds set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific CMake, and OpenSSL libraries built for Android in order to build this demo with secure WebSocket support. The native build expects `OPENSSL_ROOT_DIR` (and `openssl.dir` in `local.properties`) to point to a directory that contains per-ABI `include` and `lib` subdirectories. For desktop builds set `OPENSSL_ROOT_DIR` to the root of your OpenSSL installation if it's not in a standard location.
 Good thing is, you only really need the SDK and NDK parts; Gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tell me why if it isn't!), but it seems to work.
 
 ### Android
 
-You'll need OpenJDK 1.8, Android SDK, NDK, and Android-specific cmake in order to build this demo. Good thing is, you only really need the
+You'll need OpenJDK 1.8, Android SDK, NDK, Android-specific cmake, and OpenSSL libraries (`libssl-dev`) in order to build this demo with secure WebSocket support. Good thing is, you only really need the
 SDK and NDK parts, gradle will install everything else for you if you accept the licenses. In order to accept the licenses, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
@@ -41,7 +41,7 @@ and accept the licenses. If you don't have an NDK, run
 
     ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager ndk-bundle
 
-This will download the latest NDK and put it into `${ANDROID_SDK_ROOT}/ndk-bundle`.
+This will download the latest NDK and put it into `${ANDROID_SDK_ROOT}/ndk-bundle`. Ensure both `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables are set so Gradle can locate the SDK and NDK.
 
 Then, download the project and its submodules:
 

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,0 +1,2 @@
+sdk.dir=/path/to/android/sdk
+ndk.dir=/path/to/android/sdk/ndk/25.2.9519653

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,3 +1,2 @@
 sdk.dir=/path/to/android/sdk
 ndk.dir=/path/to/android/sdk/ndk/25.2.9519653
-openssl.dir=/path/to/prebuilt/openssl

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,3 +1,2 @@
 sdk.dir=/path/to/android/sdk
 ndk.dir=/path/to/android/sdk/ndk/25.2.9519653
-openssl.dir=/path/to/openssl

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,2 +1,3 @@
 sdk.dir=/path/to/android/sdk
 ndk.dir=/path/to/android/sdk/ndk/25.2.9519653
+openssl.dir=/path/to/openssl

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,2 +1,3 @@
 sdk.dir=/path/to/android/sdk
 ndk.dir=/path/to/android/sdk/ndk/25.2.9519653
+openssl.dir=/path/to/prebuilt/openssl


### PR DESCRIPTION
## Summary
- Allow secure WebSocket traffic by adding Internet permission and network security config
- Install OpenSSL libs and expose SDK/NDK paths in CI workflows
- Document OpenSSL requirement and SDK/NDK environment variables

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ac2d313083208d2794cfd79816be